### PR TITLE
add gitignore to the bun-fullstack example

### DIFF
--- a/examples/bun-fullstack/.gitignore
+++ b/examples/bun-fullstack/.gitignore
@@ -1,0 +1,42 @@
+# Dependencies
+node_modules/
+bun.lockb
+
+# Build outputs
+dist/
+build/
+*.tsbuildinfo
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Testing
+coverage/
+.nyc_output/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# OS
+Thumbs.db


### PR DESCRIPTION
Adding a gitignore file so when using bunx degit to get the sample and generally using it one gets a clean start when initializing a repo