### PR TITLE
Add SQL schema introspection with multi-dialect support

### DIFF
--- a/src/SqlIntrospect.test.ts
+++ b/src/SqlIntrospect.test.ts
@@ -1,0 +1,660 @@
+import * as test from "bun:test"
+import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
+import * as Sql from "./sql/Sql.ts"
+import * as SqlIntrospect from "./SqlIntrospect.ts"
+import * as BunSql from "./sql/bun/index.ts"
+
+const runSql = <A, E>(effect: Effect.Effect<A, E, Sql.SqlClient>) =>
+  Effect.runPromise(
+    Effect.provide(effect, BunSql.layer({ adapter: "sqlite", filename: ":memory:" })),
+  )
+
+const setupTestDb = Effect.gen(function* () {
+  const sql = yield* Sql.SqlClient
+  yield* sql`CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT,
+    age INTEGER DEFAULT 0,
+    active BOOLEAN NOT NULL DEFAULT 1
+  )`
+  yield* sql`CREATE TABLE posts (
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    body TEXT,
+    score REAL,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE
+  )`
+  yield* sql`CREATE INDEX idx_posts_user_id ON posts(user_id)`
+  yield* sql`CREATE UNIQUE INDEX idx_users_email ON users(email)`
+
+  yield* sql`INSERT INTO users (name, email, age, active) VALUES (${"Alice"}, ${"alice@test.com"}, ${30}, ${1})`
+  yield* sql`INSERT INTO users (name, email, age, active) VALUES (${"Bob"}, ${"bob@test.com"}, ${25}, ${1})`
+  yield* sql`INSERT INTO users (name, email, age, active) VALUES (${"Charlie"}, ${null}, ${35}, ${0})`
+  yield* sql`INSERT INTO posts (title, body, score, user_id) VALUES (${"Hello"}, ${"World"}, ${4.5}, ${1})`
+  yield* sql`INSERT INTO posts (title, body, score, user_id) VALUES (${"Goodbye"}, ${null}, ${null}, ${2})`
+})
+
+test.describe("SqlIntrospect", () => {
+  test.describe("introspect", () => {
+    test.it("should introspect tables and columns", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const schema = yield* SqlIntrospect.introspect("sqlite")
+
+          test.expect(schema.tables).toHaveLength(2)
+
+          const users = schema.tables.find((t) => t.tableName === "users")!
+          const posts = schema.tables.find((t) => t.tableName === "posts")!
+
+          test.expect(users.columns).toHaveLength(5)
+          test.expect(users.columns[0].columnName).toBe("id")
+          test.expect(users.columns[0].isPrimaryKey).toBe(true)
+          test.expect(users.columns[0].isAutoIncrement).toBe(true)
+          test.expect(users.columns[1].columnName).toBe("name")
+          test.expect(users.columns[1].isNullable).toBe(false)
+          test.expect(users.columns[2].columnName).toBe("email")
+          test.expect(users.columns[2].isNullable).toBe(true)
+          test.expect(users.columns[3].columnDefault).toBe("0")
+
+          test.expect(posts.columns).toHaveLength(5)
+          test.expect(posts.foreignKeys).toHaveLength(1)
+          test.expect(posts.foreignKeys[0].referencedTable).toBe("users")
+          test.expect(posts.foreignKeys[0].referencedColumn).toBe("id")
+          test.expect(posts.foreignKeys[0].columnName).toBe("user_id")
+          test.expect(posts.foreignKeys[0].deleteRule).toBe("CASCADE")
+
+          test.expect(posts.indexes).toHaveLength(1)
+          test.expect(posts.indexes[0].indexName).toBe("idx_posts_user_id")
+          test.expect(posts.indexes[0].isUnique).toBe(false)
+
+          test.expect(users.indexes).toHaveLength(1)
+          test.expect(users.indexes[0].indexName).toBe("idx_users_email")
+          test.expect(users.indexes[0].isUnique).toBe(true)
+        }),
+      ),
+    )
+
+    test.it("should skip foreign keys when disabled", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const schema = yield* SqlIntrospect.introspect("sqlite", { foreignKeys: false })
+          const posts = schema.tables.find((t) => t.tableName === "posts")!
+
+          test.expect(posts.foreignKeys).toHaveLength(0)
+          test.expect(posts.indexes).toHaveLength(1)
+        }),
+      ),
+    )
+
+    test.it("should skip indexes when disabled", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const schema = yield* SqlIntrospect.introspect("sqlite", { indexes: false })
+          const posts = schema.tables.find((t) => t.tableName === "posts")!
+
+          test.expect(posts.foreignKeys).toHaveLength(1)
+          test.expect(posts.indexes).toHaveLength(0)
+        }),
+      ),
+    )
+
+    test.it("should skip both when disabled", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const schema = yield* SqlIntrospect.introspect("sqlite", {
+            foreignKeys: false,
+            indexes: false,
+          })
+          const posts = schema.tables.find((t) => t.tableName === "posts")!
+
+          test.expect(posts.foreignKeys).toHaveLength(0)
+          test.expect(posts.indexes).toHaveLength(0)
+          test.expect(posts.columns).toHaveLength(5)
+        }),
+      ),
+    )
+
+    test.it("should return empty schema for empty database", () =>
+      runSql(
+        Effect.gen(function* () {
+          const schema = yield* SqlIntrospect.introspect("sqlite")
+
+          test.expect(schema.tables).toHaveLength(0)
+        }),
+      ),
+    )
+  })
+
+  test.describe("isSortable", () => {
+    test.it("primary key columns should be sortable", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const users = db.tables.find((t) => t.tableName === "users")!
+          const id = users.columns.find((c) => c.columnName === "id")!
+
+          test.expect(id.isSortable).toBe(true)
+        }),
+      ),
+    )
+
+    test.it("single-column indexed columns should be sortable", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const users = db.tables.find((t) => t.tableName === "users")!
+          const email = users.columns.find((c) => c.columnName === "email")!
+
+          test.expect(email.isSortable).toBe(true)
+
+          const posts = db.tables.find((t) => t.tableName === "posts")!
+          const userId = posts.columns.find((c) => c.columnName === "user_id")!
+
+          test.expect(userId.isSortable).toBe(true)
+        }),
+      ),
+    )
+
+    test.it("unindexed columns should not be sortable", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const users = db.tables.find((t) => t.tableName === "users")!
+          const name = users.columns.find((c) => c.columnName === "name")!
+
+          test.expect(name.isSortable).toBe(false)
+
+          const age = users.columns.find((c) => c.columnName === "age")!
+
+          test.expect(age.isSortable).toBe(false)
+        }),
+      ),
+    )
+
+    test.it("composite index columns should not be sortable individually", () =>
+      runSql(
+        Effect.gen(function* () {
+          const sql = yield* Sql.SqlClient
+          yield* sql`CREATE TABLE composite (id INTEGER PRIMARY KEY, a TEXT, b TEXT)`
+          yield* sql`CREATE INDEX idx_composite_ab ON composite(a, b)`
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const table = db.tables.find((t) => t.tableName === "composite")!
+          const a = table.columns.find((c) => c.columnName === "a")!
+          const b = table.columns.find((c) => c.columnName === "b")!
+
+          test.expect(a.isSortable).toBe(false)
+          test.expect(b.isSortable).toBe(false)
+        }),
+      ),
+    )
+
+    test.it("without indexes introspected, only primary keys are sortable", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite", { indexes: false })
+          const users = db.tables.find((t) => t.tableName === "users")!
+          const id = users.columns.find((c) => c.columnName === "id")!
+
+          test.expect(id.isSortable).toBe(true)
+
+          const email = users.columns.find((c) => c.columnName === "email")!
+
+          test.expect(email.isSortable).toBe(false)
+        }),
+      ),
+    )
+  })
+
+  test.describe("tableToSchema", () => {
+    test.it("should map columns to Schema.Struct fields", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const users = db.tables.find((t) => t.tableName === "users")!
+          const ts = SqlIntrospect.tableToSchema(users)!
+
+          test.expect(ts.tableName).toBe("users")
+          test.expect(ts.columns).toHaveLength(5)
+
+          const decoded = Schema.decodeUnknownSync(ts.schema)({
+            id: 1,
+            name: "Alice",
+            email: null,
+            age: 30,
+            active: true,
+          })
+
+          test.expect(decoded).toEqual({
+            id: 1,
+            name: "Alice",
+            email: null,
+            age: 30,
+            active: true,
+          })
+        }),
+      ),
+    )
+
+    test.it("should handle nullable columns with NullOr", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const posts = db.tables.find((t) => t.tableName === "posts")!
+          const ts = SqlIntrospect.tableToSchema(posts)!
+
+          const decoded = Schema.decodeUnknownSync(ts.schema)({
+            id: 1,
+            title: "Hello",
+            body: null,
+            score: null,
+            user_id: 1,
+          })
+
+          test.expect(decoded.body).toBeNull()
+          test.expect(decoded.score).toBeNull()
+        }),
+      ),
+    )
+
+    test.it("should skip unmappable columns (blob)", () =>
+      runSql(
+        Effect.gen(function* () {
+          const sql = yield* Sql.SqlClient
+          yield* sql`CREATE TABLE blobs (id INTEGER PRIMARY KEY, data BLOB, name TEXT)`
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const table = db.tables.find((t) => t.tableName === "blobs")!
+          const ts = SqlIntrospect.tableToSchema(table)!
+
+          test.expect(ts.columns).toHaveLength(2)
+          test.expect(ts.columns.map((c) => c.columnName)).toEqual(["id", "name"])
+        }),
+      ),
+    )
+
+    test.it("should return null for table with only unmappable columns", () =>
+      runSql(
+        Effect.gen(function* () {
+          const sql = yield* Sql.SqlClient
+          yield* sql`CREATE TABLE only_blobs (data BLOB, image BLOB)`
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const table = db.tables.find((t) => t.tableName === "only_blobs")!
+          const ts = SqlIntrospect.tableToSchema(table)
+
+          test.expect(ts).toBeNull()
+        }),
+      ),
+    )
+  })
+
+  test.describe("toSchemas", () => {
+    test.it("should convert all tables to schemas, skipping unmappable", () =>
+      runSql(
+        Effect.gen(function* () {
+          const sql = yield* Sql.SqlClient
+          yield* sql`CREATE TABLE mappable (id INTEGER PRIMARY KEY, name TEXT)`
+          yield* sql`CREATE TABLE unmappable (data BLOB)`
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const schemas = SqlIntrospect.toSchemas(db)
+
+          test.expect(schemas).toHaveLength(1)
+          test.expect(schemas[0].tableName).toBe("mappable")
+        }),
+      ),
+    )
+  })
+
+  test.describe("DatabaseReader", () => {
+    test.it("findAll should return all rows", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll()
+
+          test.expect(rows).toHaveLength(3)
+        }),
+      ),
+    )
+
+    test.it("findAll should support limit and offset", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll({
+            limit: 1,
+            offset: 1,
+            sort: [{ column: "id" }],
+          })
+
+          test.expect(rows).toHaveLength(1)
+          test.expect((rows[0] as any).name).toBe("Bob")
+        }),
+      ),
+    )
+
+    test.it("sortableColumns should list sortable column names", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+
+          test.expect([...users.sortableColumns].sort()).toEqual(["email", "id"])
+
+          const posts = reader.table("posts")!
+
+          test.expect([...posts.sortableColumns].sort()).toEqual(["id", "user_id"])
+        }),
+      ),
+    )
+
+    test.it("findAll should sort ascending by default", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll({
+            sort: [{ column: "id" }],
+          })
+
+          test.expect((rows[0] as any).id).toBe(1)
+          test.expect((rows[2] as any).id).toBe(3)
+        }),
+      ),
+    )
+
+    test.it("findAll should sort descending with reverse", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll({
+            sort: [{ column: "id", reverse: true }],
+          })
+
+          test.expect((rows[0] as any).id).toBe(3)
+          test.expect((rows[2] as any).id).toBe(1)
+        }),
+      ),
+    )
+
+    test.it("findAll should ignore sort on non-sortable columns", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll({
+            sort: [{ column: "name", reverse: true }],
+          })
+
+          test.expect(rows).toHaveLength(3)
+        }),
+      ),
+    )
+
+    test.it("findAll should support multiple sort columns", () =>
+      runSql(
+        Effect.gen(function* () {
+          const sql = yield* Sql.SqlClient
+          yield* sql`CREATE TABLE items (id INTEGER PRIMARY KEY, category INTEGER, name TEXT)`
+          yield* sql`CREATE INDEX idx_items_category ON items(category)`
+          yield* sql`INSERT INTO items (category, name) VALUES (${2}, ${"B"})`
+          yield* sql`INSERT INTO items (category, name) VALUES (${1}, ${"A"})`
+          yield* sql`INSERT INTO items (category, name) VALUES (${2}, ${"C"})`
+          yield* sql`INSERT INTO items (category, name) VALUES (${1}, ${"D"})`
+
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const items = reader.table("items")!
+          const rows = yield* items.findAll({
+            sort: [{ column: "category" }, { column: "id", reverse: true }],
+          })
+
+          test.expect((rows[0] as any).category).toBe(1)
+          test.expect((rows[0] as any).name).toBe("D")
+          test.expect((rows[1] as any).category).toBe(1)
+          test.expect((rows[1] as any).name).toBe("A")
+          test.expect((rows[2] as any).category).toBe(2)
+        }),
+      ),
+    )
+
+    test.describe("filters", () => {
+      test.it("findAll should filter with eq", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "name", op: "eq", value: "Alice" }],
+            })
+
+            test.expect(rows).toHaveLength(1)
+            test.expect((rows[0] as any).name).toBe("Alice")
+          }),
+        ),
+      )
+
+      test.it("findAll should filter with neq", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "name", op: "neq", value: "Alice" }],
+            })
+
+            test.expect(rows).toHaveLength(2)
+            test.expect((rows as Array<any>).every((r) => r.name !== "Alice")).toBe(true)
+          }),
+        ),
+      )
+
+      test.it("findAll should filter null with eq (IS NULL)", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "email", op: "eq", value: null }],
+            })
+
+            test.expect(rows).toHaveLength(1)
+            test.expect((rows[0] as any).name).toBe("Charlie")
+          }),
+        ),
+      )
+
+      test.it("findAll should filter null with neq (IS NOT NULL)", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "email", op: "neq", value: null }],
+            })
+
+            test.expect(rows).toHaveLength(2)
+          }),
+        ),
+      )
+
+      test.it("findAll should support multiple filters (AND)", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [
+                { column: "active", op: "eq", value: 1 },
+                { column: "name", op: "neq", value: "Alice" },
+              ],
+            })
+
+            test.expect(rows).toHaveLength(1)
+            test.expect((rows[0] as any).name).toBe("Bob")
+          }),
+        ),
+      )
+
+      test.it("findAll should ignore filters on unknown columns", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "nonexistent", op: "eq", value: "x" }],
+            })
+
+            test.expect(rows).toHaveLength(3)
+          }),
+        ),
+      )
+
+      test.it("findAll should combine filters with sort and pagination", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const rows = yield* users.findAll({
+              filters: [{ column: "active", op: "eq", value: 1 }],
+              sort: [{ column: "id", reverse: true }],
+              limit: 1,
+            })
+
+            test.expect(rows).toHaveLength(1)
+            test.expect((rows[0] as any).name).toBe("Bob")
+          }),
+        ),
+      )
+
+      test.it("count should support filters", () =>
+        runSql(
+          Effect.gen(function* () {
+            yield* setupTestDb
+            const db = yield* SqlIntrospect.introspect("sqlite")
+            const reader = SqlIntrospect.makeDatabaseReader(db)
+            const users = reader.table("users")!
+            const total = yield* users.count()
+
+            test.expect(total).toBe(3)
+
+            const active = yield* users.count({
+              filters: [{ column: "active", op: "eq", value: 1 }],
+            })
+
+            test.expect(active).toBe(2)
+          }),
+        ),
+      )
+    })
+
+    test.it("findById should return single row", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const user = (yield* users.findById(2)) as any
+
+          test.expect(user.name).toBe("Bob")
+        }),
+      ),
+    )
+
+    test.it("findById should return null for missing row", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const user = yield* users.findById(999)
+
+          test.expect(user).toBeNull()
+        }),
+      ),
+    )
+
+    test.it("table should return undefined for unknown table", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+
+          test.expect(reader.table("nonexistent")).toBeUndefined()
+        }),
+      ),
+    )
+
+    test.it("should list all table readers", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+
+          test.expect(reader.tables).toHaveLength(2)
+          test.expect(reader.tables.map((t) => t.tableName).sort()).toEqual(["posts", "users"])
+        }),
+      ),
+    )
+
+    test.it("reader schema should validate rows", () =>
+      runSql(
+        Effect.gen(function* () {
+          yield* setupTestDb
+          const db = yield* SqlIntrospect.introspect("sqlite")
+          const reader = SqlIntrospect.makeDatabaseReader(db)
+          const users = reader.table("users")!
+          const rows = yield* users.findAll()
+          for (const row of rows) {
+            const result = Schema.decodeUnknownEither(users.schema)(row)
+
+            test.expect(result._tag).toBe("Right")
+          }
+        }),
+      ),
+    )
+  })
+})

--- a/src/SqlIntrospect.ts
+++ b/src/SqlIntrospect.ts
@@ -1,0 +1,614 @@
+import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
+import * as Sql from "./sql/Sql.ts"
+
+export interface Column {
+  readonly tableSchema: string
+  readonly tableName: string
+  readonly columnName: string
+  readonly ordinalPosition: number
+  readonly columnDefault: string | null
+  readonly isNullable: boolean
+  readonly dataType: string
+  readonly maxLength: number | null
+  readonly isPrimaryKey: boolean
+  readonly isAutoIncrement: boolean
+  readonly isSortable: boolean
+}
+
+export interface ForeignKey {
+  readonly constraintName: string
+  readonly tableSchema: string
+  readonly tableName: string
+  readonly columnName: string
+  readonly referencedSchema: string
+  readonly referencedTable: string
+  readonly referencedColumn: string
+  readonly updateRule: string
+  readonly deleteRule: string
+}
+
+export interface Index {
+  readonly tableSchema: string
+  readonly tableName: string
+  readonly indexName: string
+  readonly columnName: string
+  readonly isUnique: boolean
+  readonly ordinalPosition: number
+}
+
+export interface Table {
+  readonly tableSchema: string
+  readonly tableName: string
+  readonly columns: ReadonlyArray<Column>
+  readonly foreignKeys: ReadonlyArray<ForeignKey>
+  readonly indexes: ReadonlyArray<Index>
+}
+
+export interface DatabaseSchema {
+  readonly tables: ReadonlyArray<Table>
+}
+
+export interface IntrospectOptions {
+  readonly foreignKeys?: boolean
+  readonly indexes?: boolean
+}
+
+const sqliteColumns = `
+  SELECT
+    '' as tableSchema,
+    m.name as tableName,
+    p.name as columnName,
+    p.cid + 1 as ordinalPosition,
+    p.dflt_value as columnDefault,
+    CASE WHEN p."notnull" = 0 THEN 1 ELSE 0 END as isNullable,
+    p.type as dataType,
+    NULL as maxLength,
+    p.pk as isPrimaryKey,
+    CASE WHEN p.pk = 1 AND lower(p.type) = 'integer' THEN 1 ELSE 0 END as isAutoIncrement
+  FROM sqlite_master m
+  JOIN pragma_table_info(m.name) p
+  WHERE m.type = 'table'
+    AND m.name NOT LIKE 'sqlite_%'
+  ORDER BY m.name, p.cid
+`
+
+const sqliteForeignKeys = `
+  SELECT
+    '' as constraintName,
+    '' as tableSchema,
+    m.name as tableName,
+    fk."from" as columnName,
+    '' as referencedSchema,
+    fk."table" as referencedTable,
+    fk."to" as referencedColumn,
+    fk.on_update as updateRule,
+    fk.on_delete as deleteRule
+  FROM sqlite_master m
+  JOIN pragma_foreign_key_list(m.name) fk
+  WHERE m.type = 'table'
+    AND m.name NOT LIKE 'sqlite_%'
+  ORDER BY m.name, fk.seq
+`
+
+const sqliteIndexes = `
+  SELECT
+    '' as tableSchema,
+    m.name as tableName,
+    il.name as indexName,
+    ii.name as columnName,
+    il."unique" as isUnique,
+    ii.seqno + 1 as ordinalPosition
+  FROM sqlite_master m
+  JOIN pragma_index_list(m.name) il
+  JOIN pragma_index_info(il.name) ii
+  WHERE m.type = 'table'
+    AND m.name NOT LIKE 'sqlite_%'
+  ORDER BY m.name, il.name, ii.seqno
+`
+
+const postgresColumns = `
+  SELECT
+    c.table_schema as "tableSchema",
+    c.table_name as "tableName",
+    c.column_name as "columnName",
+    c.ordinal_position as "ordinalPosition",
+    c.column_default as "columnDefault",
+    CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END as "isNullable",
+    c.data_type as "dataType",
+    c.character_maximum_length as "maxLength",
+    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as "isPrimaryKey",
+    CASE WHEN c.column_default LIKE 'nextval(%' THEN true ELSE false END as "isAutoIncrement"
+  FROM information_schema.columns c
+  LEFT JOIN (
+    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+  ) pk
+    ON c.table_schema = pk.table_schema
+    AND c.table_name = pk.table_name
+    AND c.column_name = pk.column_name
+  WHERE c.table_schema NOT IN ('information_schema', 'pg_catalog')
+  ORDER BY c.table_schema, c.table_name, c.ordinal_position
+`
+
+const postgresForeignKeys = `
+  SELECT
+    tc.constraint_name as "constraintName",
+    tc.table_schema as "tableSchema",
+    tc.table_name as "tableName",
+    kcu.column_name as "columnName",
+    ccu.table_schema as "referencedSchema",
+    ccu.table_name as "referencedTable",
+    ccu.column_name as "referencedColumn",
+    rc.update_rule as "updateRule",
+    rc.delete_rule as "deleteRule"
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+    AND tc.table_schema = kcu.table_schema
+  JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name
+    AND tc.table_schema = ccu.table_schema
+  JOIN information_schema.referential_constraints rc
+    ON tc.constraint_name = rc.constraint_name
+    AND tc.table_schema = rc.constraint_schema
+  WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema NOT IN ('information_schema', 'pg_catalog')
+  ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+`
+
+const postgresIndexes = `
+  SELECT
+    n.nspname as "tableSchema",
+    t.relname as "tableName",
+    i.relname as "indexName",
+    a.attname as "columnName",
+    ix.indisunique as "isUnique",
+    array_position(ix.indkey, a.attnum) as "ordinalPosition"
+  FROM pg_index ix
+  JOIN pg_class t ON t.oid = ix.indrelid
+  JOIN pg_class i ON i.oid = ix.indexrelid
+  JOIN pg_namespace n ON n.oid = t.relnamespace
+  JOIN pg_attribute a ON a.attrelid = t.oid
+    AND a.attnum = ANY(ix.indkey)
+  WHERE n.nspname NOT IN ('information_schema', 'pg_catalog')
+  ORDER BY n.nspname, t.relname, i.relname, array_position(ix.indkey, a.attnum)
+`
+
+const mssqlColumns = `
+  SELECT
+    s.name as tableSchema,
+    t.name as tableName,
+    c.name as columnName,
+    c.column_id as ordinalPosition,
+    dc.definition as columnDefault,
+    c.is_nullable as isNullable,
+    tp.name as dataType,
+    c.max_length as maxLength,
+    CASE WHEN pk.column_id IS NOT NULL THEN 1 ELSE 0 END as isPrimaryKey,
+    c.is_identity as isAutoIncrement
+  FROM sys.tables t
+  JOIN sys.schemas s ON t.schema_id = s.schema_id
+  JOIN sys.columns c ON t.object_id = c.object_id
+  JOIN sys.types tp ON c.user_type_id = tp.user_type_id
+  LEFT JOIN sys.default_constraints dc ON c.default_object_id = dc.object_id
+  LEFT JOIN (
+    SELECT ic.object_id, ic.column_id
+    FROM sys.index_columns ic
+    JOIN sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+    WHERE i.is_primary_key = 1
+  ) pk ON c.object_id = pk.object_id AND c.column_id = pk.column_id
+  WHERE t.is_ms_shipped = 0
+  ORDER BY s.name, t.name, c.column_id
+`
+
+const mssqlForeignKeys = `
+  SELECT
+    fk.name as constraintName,
+    s.name as tableSchema,
+    t.name as tableName,
+    c.name as columnName,
+    rs.name as referencedSchema,
+    rt.name as referencedTable,
+    rc.name as referencedColumn,
+    fk.update_referential_action_desc as updateRule,
+    fk.delete_referential_action_desc as deleteRule
+  FROM sys.foreign_keys fk
+  JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+  JOIN sys.tables t ON fkc.parent_object_id = t.object_id
+  JOIN sys.schemas s ON t.schema_id = s.schema_id
+  JOIN sys.columns c ON fkc.parent_object_id = c.object_id AND fkc.parent_column_id = c.column_id
+  JOIN sys.tables rt ON fkc.referenced_object_id = rt.object_id
+  JOIN sys.schemas rs ON rt.schema_id = rs.schema_id
+  JOIN sys.columns rc ON fkc.referenced_object_id = rc.object_id AND fkc.referenced_column_id = rc.column_id
+  WHERE t.is_ms_shipped = 0
+  ORDER BY s.name, t.name, fkc.constraint_column_id
+`
+
+const mssqlIndexes = `
+  SELECT
+    s.name as tableSchema,
+    t.name as tableName,
+    i.name as indexName,
+    c.name as columnName,
+    i.is_unique as isUnique,
+    ic.key_ordinal as ordinalPosition
+  FROM sys.indexes i
+  JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+  JOIN sys.tables t ON i.object_id = t.object_id
+  JOIN sys.schemas s ON t.schema_id = s.schema_id
+  JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+  WHERE t.is_ms_shipped = 0
+    AND i.name IS NOT NULL
+    AND i.is_primary_key = 0
+    AND ic.is_included_column = 0
+  ORDER BY s.name, t.name, i.name, ic.key_ordinal
+`
+
+export type Dialect = "sqlite" | "postgres" | "mssql"
+
+const dialectQueries: Record<Dialect, { columns: string; foreignKeys: string; indexes: string }> = {
+  sqlite: { columns: sqliteColumns, foreignKeys: sqliteForeignKeys, indexes: sqliteIndexes },
+  postgres: {
+    columns: postgresColumns,
+    foreignKeys: postgresForeignKeys,
+    indexes: postgresIndexes,
+  },
+  mssql: { columns: mssqlColumns, foreignKeys: mssqlForeignKeys, indexes: mssqlIndexes },
+}
+
+const singleColumnIndexes = (indexes: ReadonlyArray<Index>): Set<string> => {
+  const countByIndex = new Map<string, { count: number; columnName: string }>()
+  for (const idx of indexes) {
+    const key = `${idx.tableSchema}.${idx.tableName}.${idx.indexName}`
+    const existing = countByIndex.get(key)
+    if (existing) {
+      existing.count++
+    } else {
+      countByIndex.set(key, { count: 1, columnName: idx.columnName })
+    }
+  }
+  const result = new Set<string>()
+  for (const [key, entry] of countByIndex) {
+    if (entry.count === 1) {
+      const tableKey = key.substring(0, key.lastIndexOf("."))
+      result.add(`${tableKey}.${entry.columnName}`)
+    }
+  }
+  return result
+}
+
+const groupByTable = (
+  columns: ReadonlyArray<Omit<Column, "isSortable">>,
+  foreignKeys: ReadonlyArray<ForeignKey>,
+  indexes: ReadonlyArray<Index>,
+): ReadonlyArray<Table> => {
+  const sortable = singleColumnIndexes(indexes)
+  const tableMap = new Map<string, Table>()
+  for (const col of columns) {
+    const key = `${col.tableSchema}.${col.tableName}`
+    const fullCol: Column = {
+      ...col,
+      isSortable: col.isPrimaryKey || sortable.has(`${key}.${col.columnName}`),
+    }
+    const existing = tableMap.get(key)
+    if (existing) {
+      ;(existing.columns as Array<Column>).push(fullCol)
+    } else {
+      tableMap.set(key, {
+        tableSchema: col.tableSchema,
+        tableName: col.tableName,
+        columns: [fullCol],
+        foreignKeys: [],
+        indexes: [],
+      })
+    }
+  }
+  for (const fk of foreignKeys) {
+    const key = `${fk.tableSchema}.${fk.tableName}`
+    const table = tableMap.get(key)
+    if (table) {
+      ;(table.foreignKeys as Array<ForeignKey>).push(fk)
+    }
+  }
+  for (const idx of indexes) {
+    const key = `${idx.tableSchema}.${idx.tableName}`
+    const table = tableMap.get(key)
+    if (table) {
+      ;(table.indexes as Array<Index>).push(idx)
+    }
+  }
+  return Array.from(tableMap.values())
+}
+
+const normalizeBooleans = (columns: ReadonlyArray<Column>): ReadonlyArray<Column> =>
+  columns.map((c) => ({
+    ...c,
+    isNullable: Boolean(c.isNullable),
+    isPrimaryKey: Boolean(c.isPrimaryKey),
+    isAutoIncrement: Boolean(c.isAutoIncrement),
+  }))
+
+export const introspect = (
+  dialect: Dialect,
+  options?: IntrospectOptions,
+): Effect.Effect<DatabaseSchema, Sql.SqlError, Sql.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Sql.SqlClient
+    const q = dialectQueries[dialect]
+    const columns = normalizeBooleans(yield* sql.unsafe<Column>(q.columns))
+    const foreignKeys =
+      options?.foreignKeys !== false ? yield* sql.unsafe<ForeignKey>(q.foreignKeys) : []
+    const indexes =
+      options?.indexes !== false
+        ? (yield* sql.unsafe<Index>(q.indexes)).map((i) => ({
+            ...i,
+            isUnique: Boolean(i.isUnique),
+          }))
+        : []
+    return { tables: groupByTable(columns, foreignKeys, indexes) }
+  })
+
+const dataTypeToSchema = (dataType: string): Schema.Schema.Any | null => {
+  const t = dataType.toLowerCase()
+  if (
+    t === "integer" ||
+    t === "int" ||
+    t === "int4" ||
+    t === "int8" ||
+    t === "smallint" ||
+    t === "tinyint" ||
+    t === "mediumint" ||
+    t === "bigint" ||
+    t === "int2"
+  )
+    return Schema.Number
+  if (
+    t === "real" ||
+    t === "double" ||
+    t === "double precision" ||
+    t === "float" ||
+    t === "float4" ||
+    t === "float8" ||
+    t === "numeric" ||
+    t === "decimal" ||
+    t === "money" ||
+    t === "smallmoney"
+  )
+    return Schema.Number
+  if (
+    t === "text" ||
+    t === "varchar" ||
+    t === "char" ||
+    t === "nchar" ||
+    t === "nvarchar" ||
+    t === "ntext" ||
+    t === "character varying" ||
+    t === "character" ||
+    t === "bpchar" ||
+    t === "uuid" ||
+    t === "citext" ||
+    t === "name" ||
+    t === "xml"
+  )
+    return Schema.String
+  if (t === "boolean" || t === "bool" || t === "bit")
+    return Schema.Union(Schema.Boolean, Schema.Number)
+  if (
+    t === "timestamp" ||
+    t === "timestamptz" ||
+    t === "timestamp with time zone" ||
+    t === "timestamp without time zone" ||
+    t === "date" ||
+    t === "datetime" ||
+    t === "datetime2" ||
+    t === "smalldatetime" ||
+    t === "datetimeoffset" ||
+    t === "time"
+  )
+    return Schema.String
+  if (t === "json" || t === "jsonb") return Schema.Unknown
+  if (t === "blob" || t === "bytea" || t === "varbinary" || t === "binary" || t === "image")
+    return null
+  return null
+}
+
+const columnToSchema = (col: Column): Schema.Schema.Any | Schema.PropertySignature.All | null => {
+  const base = dataTypeToSchema(col.dataType)
+  if (base === null) return null
+  if (col.isNullable) return Schema.NullOr(base)
+  return base
+}
+
+export interface TableSchema {
+  readonly tableName: string
+  readonly tableSchema: string
+  readonly schema: Schema.Schema<any, any, never>
+  readonly columns: ReadonlyArray<Column>
+}
+
+export const tableToSchema = (table: Table): TableSchema | null => {
+  const fields: Record<string, Schema.Schema<any, any, never>> = {}
+  let hasFields = false
+  for (const col of table.columns) {
+    const s = columnToSchema(col)
+    if (s === null) continue
+    fields[col.columnName] = s as Schema.Schema<any, any, never>
+    hasFields = true
+  }
+  if (!hasFields) return null
+  return {
+    tableName: table.tableName,
+    tableSchema: table.tableSchema,
+    schema: Schema.Struct(fields),
+    columns: table.columns.filter((c) => columnToSchema(c) !== null),
+  }
+}
+
+export const toSchemas = (db: DatabaseSchema): ReadonlyArray<TableSchema> =>
+  db.tables.flatMap((t) => {
+    const s = tableToSchema(t)
+    return s ? [s] : []
+  })
+
+export interface SortOrder {
+  readonly column: string
+  readonly reverse?: boolean
+}
+
+export interface Filter {
+  readonly column: string
+  readonly op: "eq" | "neq"
+  readonly value: unknown
+}
+
+export interface FindAllOptions {
+  readonly limit?: number
+  readonly offset?: number
+  readonly sort?: ReadonlyArray<SortOrder>
+  readonly filters?: ReadonlyArray<Filter>
+}
+
+export interface TableReader {
+  readonly tableName: string
+  readonly tableSchema: string
+  readonly schema: Schema.Schema<any, any, never>
+  readonly columns: ReadonlyArray<Column>
+  readonly sortableColumns: ReadonlyArray<string>
+  readonly findAll: (
+    options?: FindAllOptions,
+  ) => Effect.Effect<ReadonlyArray<unknown>, Sql.SqlError, Sql.SqlClient>
+  readonly findById: (id: unknown) => Effect.Effect<unknown | null, Sql.SqlError, Sql.SqlClient>
+  readonly count: (options?: {
+    readonly filters?: ReadonlyArray<Filter>
+  }) => Effect.Effect<number, Sql.SqlError, Sql.SqlClient>
+}
+
+export interface DatabaseReader {
+  readonly tables: ReadonlyArray<TableReader>
+  readonly table: (name: string) => TableReader | undefined
+}
+
+const escapeIdentifier = (id: string): string => `"${id.replace(/"/g, '""')}"`
+
+const concatSql = (
+  sql: Sql.SqlQuery,
+  fragments: Array<{ strings: ReadonlyArray<string>; values: Array<unknown> }>,
+): Effect.Effect<ReadonlyArray<unknown>, Sql.SqlError> => {
+  const strings: Array<string> = []
+  const values: Array<unknown> = []
+  for (let i = 0; i < fragments.length; i++) {
+    const frag = fragments[i]
+    for (let j = 0; j < frag.strings.length; j++) {
+      if (j === 0 && strings.length > 0) {
+        strings[strings.length - 1] += frag.strings[j]
+      } else {
+        strings.push(frag.strings[j])
+      }
+      if (j < frag.values.length) values.push(frag.values[j])
+    }
+  }
+  const tsa = Object.assign([...strings], { raw: strings }) as unknown as TemplateStringsArray
+  return sql(tsa, ...values)
+}
+
+const literal = (text: string) => ({ strings: [text], values: [] as Array<unknown> })
+
+const param = (value: unknown) => ({ strings: ["", ""], values: [value] })
+
+const buildWhereFragments = (
+  filters: ReadonlyArray<Filter>,
+  columnSet: Set<string>,
+): Array<{ strings: ReadonlyArray<string>; values: Array<unknown> }> => {
+  const parts: Array<{ strings: ReadonlyArray<string>; values: Array<unknown> }> = []
+  const valid = filters.filter((f) => columnSet.has(f.column))
+  if (valid.length === 0) return parts
+  parts.push(literal(" WHERE "))
+  for (let i = 0; i < valid.length; i++) {
+    if (i > 0) parts.push(literal(" AND "))
+    const f = valid[i]
+    const col = escapeIdentifier(f.column)
+    if (f.value === null) {
+      parts.push(literal(f.op === "eq" ? `${col} IS NULL` : `${col} IS NOT NULL`))
+    } else {
+      parts.push(literal(`${col} ${f.op === "eq" ? "=" : "!="} `))
+      parts.push(param(f.value))
+    }
+  }
+  return parts
+}
+
+const makeTableReader = (ts: TableSchema): TableReader => {
+  const qualifiedName = ts.tableSchema
+    ? `${escapeIdentifier(ts.tableSchema)}.${escapeIdentifier(ts.tableName)}`
+    : escapeIdentifier(ts.tableName)
+  const primaryKey = ts.columns.find((c) => c.isPrimaryKey)
+  const selectCols = ts.columns.map((c) => escapeIdentifier(c.columnName)).join(", ")
+  const columnSet = new Set(ts.columns.map((c) => c.columnName))
+  const sortableSet = new Set(ts.columns.filter((c) => c.isSortable).map((c) => c.columnName))
+
+  return {
+    tableName: ts.tableName,
+    tableSchema: ts.tableSchema,
+    schema: ts.schema,
+    columns: ts.columns,
+    sortableColumns: Array.from(sortableSet),
+    findAll: (options) =>
+      Effect.gen(function* () {
+        const sql = yield* Sql.SqlClient
+        const fragments: Array<{ strings: ReadonlyArray<string>; values: Array<unknown> }> = [
+          literal(`SELECT ${selectCols} FROM ${qualifiedName}`),
+        ]
+        if (options?.filters) {
+          fragments.push(...buildWhereFragments(options.filters, columnSet))
+        }
+        if (options?.sort && options.sort.length > 0) {
+          const sortClauses = options.sort
+            .filter((s) => sortableSet.has(s.column))
+            .map((s) => `${escapeIdentifier(s.column)} ${s.reverse ? "DESC" : "ASC"}`)
+          if (sortClauses.length > 0) fragments.push(literal(` ORDER BY ${sortClauses.join(", ")}`))
+        }
+        if (options?.limit !== undefined)
+          fragments.push(literal(` LIMIT ${Math.trunc(Number(options.limit))}`))
+        if (options?.offset !== undefined)
+          fragments.push(literal(` OFFSET ${Math.trunc(Number(options.offset))}`))
+        return yield* concatSql(sql, fragments)
+      }),
+    findById: (id) =>
+      Effect.gen(function* () {
+        if (!primaryKey) return null
+        const sql = yield* Sql.SqlClient
+        const pkCol = escapeIdentifier(primaryKey.columnName)
+        const rows = yield* concatSql(sql, [
+          literal(`SELECT ${selectCols} FROM ${qualifiedName} WHERE ${pkCol} = `),
+          param(id),
+        ])
+        return rows[0] ?? null
+      }),
+    count: (options) =>
+      Effect.gen(function* () {
+        const sql = yield* Sql.SqlClient
+        const fragments: Array<{ strings: ReadonlyArray<string>; values: Array<unknown> }> = [
+          literal(`SELECT COUNT(*) as count FROM ${qualifiedName}`),
+        ]
+        if (options?.filters) {
+          fragments.push(...buildWhereFragments(options.filters, columnSet))
+        }
+        const rows = yield* concatSql(sql, fragments)
+        return Number((rows[0] as any).count)
+      }),
+  }
+}
+
+export const makeDatabaseReader = (db: DatabaseSchema): DatabaseReader => {
+  const schemas = toSchemas(db)
+  const readers = schemas.map(makeTableReader)
+  return {
+    tables: readers,
+    table: (name) => readers.find((r) => r.tableName === name),
+  }
+}


### PR DESCRIPTION
  ## Summary                                                                                                                             
  - Add `SqlIntrospect` module that introspects database schemas (tables, columns, foreign keys, indexes) with support for SQLite,       
  PostgreSQL, and MSSQL dialects
  - Generate Effect `Schema` definitions from introspected tables, with automatic type mapping (int → Number, text → String, nullable →
  NullOr, etc.)
  - Provide a `DatabaseReader` API for type-safe querying with filtering (eq/neq, IS NULL), sorting (with index-aware sortable column
  detection), and pagination (limit/offset)
  - Comprehensive test suite (660 lines) covering introspection, schema generation, sortability rules, and all reader operations

  ## Test plan
  - [x] Table and column introspection (types, nullability, defaults, primary keys, auto-increment)
  - [x] Foreign key and index introspection with opt-out support
  - [x] `isSortable` logic: primary keys, single-column indexes sortable; composite indexes and unindexed columns not sortable
  - [x] `tableToSchema` / `toSchemas`: type mapping, nullable handling, unmappable column skipping (e.g. BLOB)
  - [x] `DatabaseReader`: findAll, findById, count, filters (eq/neq/null), multi-column sort, pagination, unknown column/table handling