### PR TITLE
fix: Route.html passes through redirect responses

### DIFF
--- a/src/RouteHttp.test.ts
+++ b/src/RouteHttp.test.ts
@@ -2256,3 +2256,25 @@ test.describe("Route.render (format=*)", () => {
     test.expect(await response.text()).toBe("<!DOCTYPE html><body>content</body>")
   })
 })
+
+test.it("Route.html handler can return redirect", async () => {
+  const handler = RouteHttp.toWebHandler(
+    Route.post(
+      Route.html(function* () {
+        yield* Effect.void
+        return Entity.make("", {
+          status: 302,
+          headers: { location: "/redirected" },
+        })
+      }),
+    ),
+  )
+  const response = await Http.fetch(handler, {
+    path: "/form",
+    method: "POST",
+  })
+
+  test.expect(response.status).toBe(302)
+  test.expect(response.headers.get("location")).toBe("/redirected")
+  test.expect(response.headers.get("content-type")).not.toContain("text/html")
+})


### PR DESCRIPTION
## Summary
- Skip content-type override in `RouteBody.build` for redirect status codes (3xx)
- Ensures `Route.html` handlers can return `Entity.make("", { status: 302, headers: { location: "..." } })` without the response being treated as HTML content

## Test plan
- [x] Added test: Route.html handler can return redirect with 302 status
- [x] All existing RouteHttp tests pass (105/105)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)