### PR TITLE
Reduce RouteBody scaffolding and simplify handler normalization

### DIFF
--- a/src/RouteBody.ts
+++ b/src/RouteBody.ts
@@ -21,21 +21,33 @@ type YieldError<T> = T extends Utils.YieldWrap<Effect.Effect<any, infer E, any>>
 
 type YieldContext<T> = T extends Utils.YieldWrap<Effect.Effect<any, any, infer R>> ? R : never
 
+type Next<B, A> = (
+  context?: Partial<B> & Record<string, unknown>,
+) => Entity.Entity<UnwrapStream<A>>
+
+type HandlerFunction<B, A, E, R> = (
+  context: Values.Simplify<B>,
+  next: Next<B, A>,
+) =>
+  | Effect.Effect<A | Entity.Entity<A>, E, R>
+  | Generator<Utils.YieldWrap<Effect.Effect<unknown, E, R>>, A | Entity.Entity<A>, unknown>
+
 export type GeneratorHandler<B, A, Y> = (
   context: Values.Simplify<B>,
-  next: (context?: Partial<B> & Record<string, unknown>) => Entity.Entity<UnwrapStream<A>>,
+  next: Next<B, A>,
 ) => Generator<Y, A | Entity.Entity<A>, never>
 
 export type HandlerInput<B, A, E, R> =
   | A
   | Entity.Entity<A>
   | Effect.Effect<A | Entity.Entity<A>, E, R>
-  | ((
-      context: Values.Simplify<B>,
-      next: (context?: Partial<B> & Record<string, unknown>) => Entity.Entity<UnwrapStream<A>>,
-    ) =>
-      | Effect.Effect<A | Entity.Entity<A>, E, R>
-      | Generator<Utils.YieldWrap<Effect.Effect<unknown, E, R>>, A | Entity.Entity<A>, unknown>)
+  | HandlerFunction<B, A, E, R>
+
+function isHandlerFunction<B, A, E, R>(
+  handler: HandlerInput<B, A, E, R>,
+): handler is HandlerFunction<B, A, E, R> {
+  return typeof handler === "function"
+}
 
 export function handle<B, A, Y extends Utils.YieldWrap<Effect.Effect<any, any, any>>>(
   handler: GeneratorHandler<B, A, Y>,
@@ -46,35 +58,31 @@ export function handle<B, A, E, R>(
 export function handle<B, A, E, R>(
   handler: HandlerInput<B, A, E, R>,
 ): Route.Route.Handler<B, A, E, R> {
-  if (typeof handler === "function") {
-    return (
-      context: B,
-      next: (context?: Partial<B> & Record<string, unknown>) => Entity.Entity<A>,
-    ): Effect.Effect<Entity.Entity<A>, E, R> => {
-      const result = (handler as Function)(context, next)
-      const effect = Effect.isEffect(result)
-        ? (result as Effect.Effect<A | Entity.Entity<A>, E, R>)
-        : (Effect.gen(function* () {
+  if (isHandlerFunction(handler)) {
+    return (context, next) => {
+      const result = handler(context as Values.Simplify<B>, next as Next<B, A>)
+      const effect: Effect.Effect<A | Entity.Entity<A>, E, R> = Effect.isEffect(result)
+        ? result
+        : Effect.gen(function* () {
             return yield* result
-          }) as Effect.Effect<A | Entity.Entity<A>, E, R>)
-      return Effect.map(effect, normalizeToEntity)
+          })
+      return effect.pipe(Effect.map((value) => normalizeToEntity(value)))
     }
   }
   if (Effect.isEffect(handler)) {
-    return (_context, _next) =>
-      Effect.map(handler, normalizeToEntity) as Effect.Effect<Entity.Entity<A>, E, R>
+    return (_context, _next) => Effect.map(handler, (value) => normalizeToEntity(value))
   }
   if (Entity.isEntity(handler)) {
     return (_context, _next) => Effect.succeed(handler as Entity.Entity<A>)
   }
-  return (_context, _next) => Effect.succeed(normalizeToEntity(handler as A) as Entity.Entity<A>)
+  return (_context, _next) => Effect.succeed(normalizeToEntity(handler))
 }
 
 function normalizeToEntity<A>(value: A | Entity.Entity<A>): Entity.Entity<A> {
   if (Entity.isEntity(value)) {
-    return value as Entity.Entity<A>
+    return value
   }
-  return Entity.make(value as A, { status: 200 })
+  return Entity.make(value, { status: 200 })
 }
 
 export interface BuildReturn<Value, F extends Format> {
@@ -108,47 +116,39 @@ export interface BuildReturn<Value, F extends Format> {
   ) => Route.RouteSet.RouteSet<D, B, [...I, Route.Route.Route<{ format: F }, {}, A, E, R>]>
 }
 
-export function build<Value, F extends Format>(descriptors: { format: F }) {
+export function build<Value, F extends Format>(descriptors: { format: F }): BuildReturn<Value, F> {
   return function <
     D extends Route.RouteDescriptor.Any,
-    B extends {},
+    B,
     I extends Route.Route.Tuple,
     A extends F extends "json" ? Value : Value | Stream.Stream<Value, any, any>,
     E = never,
     R = never,
   >(handler: HandlerInput<NoInfer<D & B & Route.ExtractBindings<I> & { format: F }>, A, E, R>) {
-    return function (self: Route.RouteSet.RouteSet<D, B, I>) {
+    return (self: Route.RouteSet.RouteSet<D, B, I>) => {
       const contentType = formatToContentType[descriptors.format]
       const baseHandler = handle(handler)
-      const wrappedHandler: Route.Route.Handler<
-        D & B & Route.ExtractBindings<I> & { format: F },
-        A,
-        E,
-        R
-      > = (ctx, next) =>
-        Effect.map(baseHandler(ctx as any, next as any), (entity) =>
-          entity.headers["content-type"]
-            ? entity
-            : Entity.make(entity.body, {
-                status: entity.status,
-                url: entity.url,
-                headers: { ...entity.headers, "content-type": contentType },
-              }),
+      const wrappedHandler: Route.Route.Handler<{ format: F }, A, E, R> = (ctx, next) =>
+        baseHandler(ctx as D & B & Route.ExtractBindings<I> & { format: F }, next).pipe(
+          Effect.map((entity) =>
+            entity.headers["content-type"] || contentType === undefined
+              ? entity
+              : Entity.make(entity.body, {
+                  status: entity.status,
+                  url: entity.url,
+                  headers: { ...entity.headers, "content-type": contentType },
+                }),
+          ),
         )
 
-      const route = Route.make<{ format: F }, {}, A, E, R>(wrappedHandler as any, descriptors)
-
-      const items: [...I, Route.Route.Route<{ format: F }, {}, A, E, R>] = [
-        ...Route.items(self),
-        route,
-      ]
+      const route = Route.make<{ format: F }, {}, A, E, R>(wrappedHandler, descriptors)
 
       return Route.set<D, B, [...I, Route.Route.Route<{ format: F }, {}, A, E, R>]>(
-        items,
+        [...Route.items(self), route],
         Route.descriptor(self),
       )
     }
-  } as unknown as BuildReturn<Value, F>
+  } as BuildReturn<Value, F>
 }
 
 export type RenderValue = string | Uint8Array | Stream.Stream<string | Uint8Array, any, any>
@@ -188,16 +188,15 @@ export function render<
   E = never,
   R = never,
 >(handler: HandlerInput<NoInfer<D & B & Route.ExtractBindings<I> & { format: "*" }>, A, E, R>) {
-  return function (self: Route.RouteSet.RouteSet<D, B, I>) {
-    const route = Route.make<{ format: "*" }, {}, A, E, R>(handle(handler) as any, { format: "*" })
-
-    const items: [...I, Route.Route.Route<{ format: "*" }, {}, A, E, R>] = [
-      ...Route.items(self),
-      route,
-    ]
+  return (self: Route.RouteSet.RouteSet<D, B, I>) => {
+    const baseHandler = handle(handler)
+    const route = Route.make<{ format: "*" }, {}, A, E, R>(
+      (ctx, next) => baseHandler(ctx as D & B & Route.ExtractBindings<I> & { format: "*" }, next),
+      { format: "*" },
+    )
 
     return Route.set<D, B, [...I, Route.Route.Route<{ format: "*" }, {}, A, E, R>]>(
-      items,
+      [...Route.items(self), route],
       Route.descriptor(self),
     )
   }


### PR DESCRIPTION
### Motivation
- Previous refactor introduced several small helper abstractions that increased file size and indirection while aiming to improve handler typing and normalization.  
- The intent is to keep the stronger typing guarantees for route handlers while removing auxiliary scaffolding so the code is more compact and easier to follow.

### Description
- Reintroduced focused aliases `Next` and `HandlerFunction` and added a typed runtime guard `isHandlerFunction` to detect function-style handlers.  
- Consolidated handler normalization directly inside `handle` to convert values, `Effect`s, and generator-style handlers into a single `Effect`-returning `Route.Route.Handler` path.  
- Inlined content-type enrichment in `build` instead of a separate helper so `Entity` headers are set consistently based on `format`.  
- Simplified `render` to use a base handler wrapper and reduced broad `any`/`unknown` assertions while preserving public API inference.

### Testing
- Ran `bun run build` which completed successfully.  
- Ran `bun test` which surfaced many pre-existing repository-level test failures (not introduced by this change), including runtime errors like `test.expectTypeOf is not a function`.  
- Ran `bun test test/RouteBody.test.ts` which exhibited the same `test.expectTypeOf` runtime issue preventing some type-level assertions from executing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc5b7affc8328907a3e21a4bc8233)