### PR TITLE
Route.Request helper for proxied origin (#94)

### DIFF
--- a/src/Route.ts
+++ b/src/Route.ts
@@ -454,6 +454,31 @@ export class Request extends Context.Tag("effect-start/Route/Request")<
   globalThis.Request
 >() {
   declare readonly [IntrinsicService]: never
+
+  /**
+   * The origin the current request was made against, honoring
+   * `X-Forwarded-Host`/`X-Forwarded-Proto` so it reflects the public origin
+   * when the app runs behind a reverse proxy.
+   */
+  static readonly origin: Effect.Effect<string, never, Request> = Effect.map(Request, requestOrigin)
+}
+
+/**
+ * Resolves the origin (scheme + host) a request was made against.
+ *
+ * Reverse proxies terminate TLS and rewrite the host before forwarding to
+ * the app, so `request.url` alone would report the internal origin. This
+ * prefers `X-Forwarded-Host`/`X-Forwarded-Proto` when present, falling back
+ * to the request URL otherwise.
+ */
+export function requestOrigin(request: globalThis.Request): string {
+  const forwardedHost = request.headers.get("x-forwarded-host")
+  if (forwardedHost) {
+    const forwardedProto = request.headers.get("x-forwarded-proto")
+    return `${forwardedProto ?? "https"}://${forwardedHost}`
+  }
+  const url = new URL(request.url)
+  return `${url.protocol}//${url.host}`
 }
 
 /**

--- a/src/experimental/CsrfProtection.ts
+++ b/src/experimental/CsrfProtection.ts
@@ -79,9 +79,7 @@ function originTrusted(
 function originMatchesBase(request: Request): boolean {
   const origin = request.headers.get("origin")
   if (origin === null || origin === "") return true
-  const url = new URL(request.url)
-  const base = `${url.protocol}//${url.host}`
-  return origin === base
+  return origin === Route.requestOrigin(request)
 }
 
 function reject(reason: string): Entity.Entity<string> {
@@ -127,8 +125,7 @@ export function make(options?: Options) {
           !originMatchesBase(request) && !originTrusted(request, trustedOrigins)
         ) {
           const origin = request.headers.get("origin")
-          const url = new URL(request.url)
-          const base = `${url.protocol}//${url.host}`
+          const base = Route.requestOrigin(request)
           return reject(
             `HTTP Origin header (${origin}) didn't match request.base_url (${base})`,
           )

--- a/test/Route.test.tsx
+++ b/test/Route.test.tsx
@@ -321,6 +321,74 @@ test.describe("Route.json", () => {
       .pipe(Effect.runPromise))
 })
 
+test.describe(Route.requestOrigin, () => {
+  test.it("uses the request URL when no forwarded headers are present", () => {
+    const request = new globalThis.Request("https://example.com/path")
+
+    test
+      .expect(Route.requestOrigin(request))
+      .toBe("https://example.com")
+  })
+
+  test.it("prefers X-Forwarded-Host/Proto over the request URL", () => {
+    const request = new globalThis.Request("http://internal:8080/path", {
+      headers: {
+        "x-forwarded-host": "example.com",
+        "x-forwarded-proto": "https",
+      },
+    })
+
+    test
+      .expect(Route.requestOrigin(request))
+      .toBe("https://example.com")
+  })
+
+  test.it("defaults X-Forwarded-Proto to https when missing", () => {
+    const request = new globalThis.Request("http://internal:8080/path", {
+      headers: { "x-forwarded-host": "example.com" },
+    })
+
+    test
+      .expect(Route.requestOrigin(request))
+      .toBe("https://example.com")
+  })
+
+  test.it("ignores X-Forwarded-Proto when X-Forwarded-Host is absent", () => {
+    const request = new globalThis.Request("http://example.com/path", {
+      headers: { "x-forwarded-proto": "https" },
+    })
+
+    test
+      .expect(Route.requestOrigin(request))
+      .toBe("http://example.com")
+  })
+
+  test.it("Route.Request.origin resolves the origin from context", () =>
+    Effect
+      .gen(function*() {
+        const handler = RouteHttp.toWebHandler(
+          Route.get(
+            Route.text(function*() {
+              return yield* Route.Request.origin
+            }),
+          ),
+        )
+        const client = Fetch.fromHandler(handler)
+
+        const entity = yield* client.get("http://localhost/test", {
+          headers: {
+            "x-forwarded-host": "app.example.com",
+            "x-forwarded-proto": "https",
+          },
+        })
+
+        test
+          .expect(yield* entity.text)
+          .toBe("https://app.example.com")
+      })
+      .pipe(Effect.runPromise))
+})
+
 test.describe(Route.redirect, () => {
   test.it("composes with Route.get", () =>
     Effect

--- a/test/experimental/CsrfProtection.test.ts
+++ b/test/experimental/CsrfProtection.test.ts
@@ -147,6 +147,46 @@ test.describe("CsrfProtection", () => {
         .pipe(Effect.runPromise))
   })
 
+  test.describe("behind a reverse proxy", () => {
+    test.it(
+      "matches origin against X-Forwarded-Host/Proto instead of request.url",
+      () =>
+        Effect
+          .gen(function*() {
+            const entity = yield* post(client, {
+              "sec-fetch-site": "same-origin",
+              "origin": "https://app.example.com",
+              "x-forwarded-host": "app.example.com",
+              "x-forwarded-proto": "https",
+            })
+
+            test
+              .expect(entity.status)
+              .toBe(200)
+          })
+          .pipe(Effect.runPromise),
+    )
+
+    test.it(
+      "still blocks when origin doesn't match the forwarded origin",
+      () =>
+        Effect
+          .gen(function*() {
+            const entity = yield* post(client, {
+              "sec-fetch-site": "same-origin",
+              "origin": "http://localhost",
+              "x-forwarded-host": "app.example.com",
+              "x-forwarded-proto": "https",
+            })
+
+            test
+              .expect(entity.status)
+              .toBe(403)
+          })
+          .pipe(Effect.runPromise),
+    )
+  })
+
   test.describe("trusted origins", () => {
     const trusted = makeHandler({
       trustedOrigins: ["https://accounts.google.com"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #94

## Summary

Adds a helper to compute the request origin that respects reverse-proxy forwarded headers (`X-Forwarded-Host` / `X-Forwarded-Proto`).

## Changes

- `Route.requestOrigin(request)` pure helper
- `Route.Request.origin` Effect for use inside handlers
- Wire CSRF protection to use the helper so same-origin checks work behind proxies

## Test plan

- [x] `bun test test/Route.test.tsx test/experimental/CsrfProtection.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

