### PR TITLE
Align Unique.snowflake with @effect/cluster Snowflake (#96)

### DIFF
--- a/src/Unique.ts
+++ b/src/Unique.ts
@@ -3,34 +3,76 @@ export const ALPHABET_BASE32_RFC4648 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 export const ALPHABET_BASE64_URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 export const ALPHABET_HEX = "0123456789abcdef"
 
+/**
+ * Millisecond epoch snowflake timestamps are relative to, matching
+ * `@effect/cluster`'s `Snowflake` module (2025-01-01T00:00:00.000Z UTC).
+ */
+export const SNOWFLAKE_EPOCH_MS = Date.UTC(2025, 0, 1)
+
+const SNOWFLAKE_MACHINE_ID_BITS = 10n
+const SNOWFLAKE_SEQUENCE_BITS = 12n
+const SNOWFLAKE_TIMESTAMP_BITS = 41n
+const SNOWFLAKE_MACHINE_ID_SHIFT = SNOWFLAKE_SEQUENCE_BITS
+const SNOWFLAKE_TIMESTAMP_SHIFT = SNOWFLAKE_MACHINE_ID_BITS + SNOWFLAKE_SEQUENCE_BITS
+const SNOWFLAKE_MACHINE_ID_MAX = (1n << SNOWFLAKE_MACHINE_ID_BITS) - 1n
+const SNOWFLAKE_SEQUENCE_MAX = (1n << SNOWFLAKE_SEQUENCE_BITS) - 1n
+const SNOWFLAKE_TIMESTAMP_MASK = (1n << SNOWFLAKE_TIMESTAMP_BITS) - 1n
+
+export interface SnowflakeParts {
+  readonly timestamp: number
+  readonly machineId: number
+  readonly sequence: number
+}
+
 interface Snowflake {
   (time?: number): bigint
   readonly state: {
-    readonly timestampMs: bigint
-    readonly sequence: bigint
+    timestampMs: bigint
+    machineId: bigint
+    sequence: bigint
   }
-  readonly timestamp: (id: bigint) => bigint
+  readonly timestamp: (id: bigint) => number
+  readonly machineId: (id: bigint) => number
+  readonly sequence: (id: bigint) => number
+  readonly toParts: (id: bigint) => SnowflakeParts
+  readonly setMachineId: (machineId: number) => void
 }
 
 /**
- * Monotonic Snowflake variant:
- * - 48-bit unix timestamp
- * - 16-bit sequence
- * - sequence resets on timestamp increment
- * - sequence overflow carries into next millisecond
- *
- * Snowflake originated at Twitter. We use 7 more bits for timestamp,
- * sacraficing shard bits, to avoid using custom epoch and use unix epoch instead.
+ * Pack timestamp, machine id and sequence parts into a snowflake id, mirroring
+ * `@effect/cluster`'s `Snowflake.make`. Machine id wraps modulo 1024 and
+ * sequence wraps modulo 4096.
  */
-function buildSnowflake(): Snowflake {
-  const timestampBits = 48n
-  const seqBits = 16n
-  const seqMax = (1n << seqBits) - 1n
-  const timestampMask = (1n << timestampBits) - 1n
+export function makeSnowflake(options: {
+  readonly timestamp: number
+  readonly machineId: number
+  readonly sequence: number
+}): bigint {
+  const relativeMs = toSafeTime(options.timestamp) - SNOWFLAKE_EPOCH_MS
+  const timestampMs = BigInt(relativeMs > 0 ? relativeMs : 0) & SNOWFLAKE_TIMESTAMP_MASK
 
+  return (timestampMs << SNOWFLAKE_TIMESTAMP_SHIFT) |
+    ((BigInt(options.machineId) & SNOWFLAKE_MACHINE_ID_MAX) << SNOWFLAKE_MACHINE_ID_SHIFT) |
+    (BigInt(options.sequence) & SNOWFLAKE_SEQUENCE_MAX)
+}
+
+/**
+ * Monotonic Snowflake generator compatible with `@effect/cluster`'s
+ * `Snowflake` layout:
+ * - 41-bit timestamp, milliseconds since `SNOWFLAKE_EPOCH_MS` (2025-01-01)
+ * - 10-bit machine id
+ * - 12-bit sequence, reset on timestamp increment, overflow carries into
+ *   the next millisecond
+ *
+ * Unlike `@effect/cluster`, machine id defaults to 0 and there's no `Clock`
+ * or `Effect` dependency, so this generator can be used standalone. Pass
+ * `machineId` (0-1023) so ids stay unique across many deployed instances.
+ */
+export function buildSnowflake(options?: { readonly machineId?: number }): Snowflake {
   const fn = Object.assign(
     (time: number = Date.now()) => {
-      const nowMs = BigInt(toSafeTime(time))
+      const relativeMs = BigInt(toSafeTime(time) - SNOWFLAKE_EPOCH_MS)
+      const nowMs = relativeMs > 0n ? relativeMs : 0n
       const timestampMs = nowMs > fn.state.timestampMs
         ? nowMs
         : fn.state.timestampMs
@@ -40,21 +82,33 @@ function buildSnowflake(): Snowflake {
         fn.state.sequence = 0n
       } else {
         fn.state.sequence += 1n
-        if (fn.state.sequence > seqMax) {
+        if (fn.state.sequence > SNOWFLAKE_SEQUENCE_MAX) {
           fn.state.timestampMs += 1n
           fn.state.sequence = 0n
         }
       }
 
-      return ((fn.state.timestampMs & timestampMask) << seqBits) |
+      return ((fn.state.timestampMs & SNOWFLAKE_TIMESTAMP_MASK) << SNOWFLAKE_TIMESTAMP_SHIFT) |
+        (fn.state.machineId << SNOWFLAKE_MACHINE_ID_SHIFT) |
         fn.state.sequence
     },
     {
       state: {
-        timestampMs: 0n,
+        timestampMs: -1n,
+        machineId: BigInt(options?.machineId ?? 0) & SNOWFLAKE_MACHINE_ID_MAX,
         sequence: -1n,
       },
-      timestamp: (id: bigint): bigint => id >> seqBits,
+      timestamp: (id: bigint): number => Number(id >> SNOWFLAKE_TIMESTAMP_SHIFT) + SNOWFLAKE_EPOCH_MS,
+      machineId: (id: bigint): number => Number((id >> SNOWFLAKE_MACHINE_ID_SHIFT) & SNOWFLAKE_MACHINE_ID_MAX),
+      sequence: (id: bigint): number => Number(id & SNOWFLAKE_SEQUENCE_MAX),
+      toParts: (id: bigint): SnowflakeParts => ({
+        timestamp: fn.timestamp(id),
+        machineId: fn.machineId(id),
+        sequence: fn.sequence(id),
+      }),
+      setMachineId: (machineId: number) => {
+        fn.state.machineId = BigInt(machineId) & SNOWFLAKE_MACHINE_ID_MAX
+      },
     },
   )
   return fn

--- a/src/studio/ui.tsx
+++ b/src/studio/ui.tsx
@@ -189,7 +189,7 @@ export function LogLine(props: { prefix: string; log: StudioStore.LogEntry }) {
 export function ErrorLine(
   props: { prefix: string; error: StudioStore.ErrorEntry },
 ) {
-  const time = new Date(Number(Unique.snowflake.timestamp(props.error.id)))
+  const time = new Date(Unique.snowflake.timestamp(props.error.id))
     .toLocaleTimeString("en", {
       hour12: false,
       hour: "2-digit",

--- a/test/Unique.test.ts
+++ b/test/Unique.test.ts
@@ -231,6 +231,118 @@ test.describe("Unique.token", () => {
   })
 })
 
+test.describe("Unique.makeSnowflake", () => {
+  test.it("packs timestamp, machineId and sequence like @effect/cluster's Snowflake.make", () => {
+    const id = Unique.makeSnowflake({
+      timestamp: Unique.SNOWFLAKE_EPOCH_MS + 5,
+      machineId: 7,
+      sequence: 3,
+    })
+
+    test.expect(id).toBe((5n << 22n) | (7n << 12n) | 3n)
+  })
+
+  test.it("wraps machineId modulo 1024 and sequence modulo 4096", () => {
+    const id = Unique.makeSnowflake({
+      timestamp: Unique.SNOWFLAKE_EPOCH_MS,
+      machineId: 1024 + 5,
+      sequence: 4096 + 9,
+    })
+
+    test.expect(id).toBe((5n << 12n) | 9n)
+  })
+
+  test.it("clamps timestamps before the snowflake epoch to zero", () => {
+    const id = Unique.makeSnowflake({
+      timestamp: 0,
+      machineId: 0,
+      sequence: 0,
+    })
+
+    test.expect(id).toBe(0n)
+  })
+})
+
+test.describe("Unique.buildSnowflake", () => {
+  test.it("encodes a 41-bit timestamp, 10-bit machineId and 12-bit sequence", () => {
+    const snowflake = Unique.buildSnowflake({ machineId: 42 })
+    const id = withNow(Unique.SNOWFLAKE_EPOCH_MS + 1000, () => snowflake())
+
+    test
+      .expect(snowflake.toParts(id))
+      .toEqual({ timestamp: Unique.SNOWFLAKE_EPOCH_MS + 1000, machineId: 42, sequence: 0 })
+  })
+
+  test.it("defaults machineId to 0 when not provided", () => {
+    const snowflake = Unique.buildSnowflake()
+    const id = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+
+    test.expect(snowflake.machineId(id)).toBe(0)
+  })
+
+  test.it("increments sequence for ids generated within the same millisecond", () => {
+    const snowflake = Unique.buildSnowflake()
+
+    const idA = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+    const idB = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+
+    test.expect(snowflake.sequence(idA)).toBe(0)
+    test.expect(snowflake.sequence(idB)).toBe(1)
+    test.expect(snowflake.timestamp(idA)).toBe(snowflake.timestamp(idB))
+    test.expect(idB > idA).toBe(true)
+  })
+
+  test.it("resets sequence to 0 when the timestamp advances", () => {
+    const snowflake = Unique.buildSnowflake()
+
+    withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+    const id = withNow(Unique.SNOWFLAKE_EPOCH_MS + 1, () => snowflake())
+
+    test.expect(snowflake.sequence(id)).toBe(0)
+    test.expect(snowflake.timestamp(id)).toBe(Unique.SNOWFLAKE_EPOCH_MS + 1)
+  })
+
+  test.it("carries sequence overflow into the next millisecond", () => {
+    const snowflake = Unique.buildSnowflake()
+
+    let last = 0n
+    for (let i = 0; i <= 4096; i++) {
+      last = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+    }
+
+    test.expect(snowflake.timestamp(last)).toBe(Unique.SNOWFLAKE_EPOCH_MS + 1)
+    test.expect(snowflake.sequence(last)).toBe(0)
+  })
+
+  test.it("stays monotonic when the clock goes backwards", () => {
+    const snowflake = Unique.buildSnowflake()
+
+    const idA = withNow(Unique.SNOWFLAKE_EPOCH_MS + 1000, () => snowflake())
+    const idB = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+
+    test.expect(idB > idA).toBe(true)
+    test.expect(snowflake.timestamp(idB)).toBe(Unique.SNOWFLAKE_EPOCH_MS + 1000)
+  })
+
+  test.it("setMachineId changes the machineId used by later ids", () => {
+    const snowflake = Unique.buildSnowflake({ machineId: 1 })
+
+    const idBefore = withNow(Unique.SNOWFLAKE_EPOCH_MS, () => snowflake())
+    snowflake.setMachineId(999)
+    const idAfter = withNow(Unique.SNOWFLAKE_EPOCH_MS + 1, () => snowflake())
+
+    test.expect(snowflake.machineId(idBefore)).toBe(1)
+    test.expect(snowflake.machineId(idAfter)).toBe(999 % 1024)
+  })
+
+  test.it("roundtrips through makeSnowflake", () => {
+    const parts = { timestamp: Unique.SNOWFLAKE_EPOCH_MS + 123456, machineId: 511, sequence: 4001 }
+    const id = Unique.makeSnowflake(parts)
+
+    test.expect(Unique.snowflake.toParts(id)).toEqual(parts)
+  })
+})
+
 test.describe("Unique.bigint", () => {
   test.it("constrains bytes into the fixed decimal range", () => {
     test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #96

## Summary

Replaces the mastodon-inspired snowflake layout with `@effect/cluster`'s Snowflake layout for Effect ecosystem compatibility, without adding `@effect/cluster` as a dependency.

## Changes

- Layout: 41-bit timestamp (epoch `2025-01-01`) / 10-bit machineId / 12-bit sequence
- Export `SNOWFLAKE_EPOCH_MS`, `makeSnowflake`, and enhance `buildSnowflake` with `machineId`, `toParts`, `setMachineId`
- Update studio caller for absolute-ms timestamp return type

## Test plan

- [x] `bun test test/Unique.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

