### PR TITLE
BundleRoute: don't rebuild on every artifact GET (#97)

### DIFF
--- a/src/bundler/BundleRoute.ts
+++ b/src/bundler/BundleRoute.ts
@@ -2,6 +2,7 @@ import type * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
+import * as Development from "../Development.ts"
 import * as Entity from "../Entity.ts"
 import * as PathPattern from "../internal/PathPattern.ts"
 import * as RouteMap from "../internal/RouteMap.ts"
@@ -25,7 +26,10 @@ export const make = <Tag extends Context.Tag<any, Bundle.BundleContext>>(
   Route.get(
     Route.handle(function*(ctx) {
       const bundle = yield* tag
-      if (bundle.rebuild) {
+      // Only rebuild when running under `Development` (dev server). In
+      // production, artifacts are static and the bundle is kept fresh via
+      // file watch + `BundleContext.events` instead of a per-request rebuild.
+      if (bundle.rebuild && Option.isSome(yield* Development.option)) {
         yield* bundle.rebuild()
       }
       const request = yield* Route.Request

--- a/test/bundler/BundleRoute.test.ts
+++ b/test/bundler/BundleRoute.test.ts
@@ -6,6 +6,7 @@ import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Bundle from "../../src/bundler/Bundle.ts"
 import * as BundleRoute from "../../src/bundler/BundleRoute.ts"
+import * as Development from "../../src/Development.ts"
 
 const testBundle: Bundle.BundleContext = {
   resolve: (url) => (url === "app.ts" ? "app-abc123.js" : undefined),
@@ -23,6 +24,25 @@ const testBundle: Bundle.BundleContext = {
 }
 
 const testLayer = Layer.succeed(Bundle.Bundle, testBundle)
+
+const makeRebuildableBundle = (): Bundle.BundleContext & {
+  rebuildCount: number
+} => {
+  const context = {
+    resolve: (url: string) => (url === "app.ts" ? "app-abc123.js" : undefined),
+    getArtifact: (path: string) =>
+      path === "app-abc123.js"
+        ? new Blob(["console.log('hello')"], { type: "application/javascript" })
+        : undefined,
+    rebuildCount: 0,
+    rebuild: () =>
+      Effect.sync(() => {
+        context.rebuildCount++
+        return context
+      }),
+  }
+  return context
+}
 
 test.it("serves a JS artifact", () =>
   Effect
@@ -105,6 +125,57 @@ test.it("returns 404 for missing artifact", () =>
       Effect.provide(testLayer),
       Effect.runPromise,
     ))
+
+test.it("does not rebuild on GET outside of Development", () => {
+  const rebuildable = makeRebuildableBundle()
+
+  return Effect
+    .gen(function*() {
+      const runtime = yield* Effect.runtime<Bundle.Bundle>()
+      const routes = BundleRoute.make(Bundle.Bundle)
+      const tree = Route.map({ "/_bundle/:path+": routes })
+      const handles = Object.fromEntries(RouteHttp.walkHandles(tree, runtime))
+      const handler = handles["/_bundle/:path+"]
+
+      const client = Fetch.fromHandler(handler)
+      yield* client.get("http://localhost/_bundle/app-abc123.js")
+      yield* client.get("http://localhost/_bundle/app-abc123.js")
+
+      test
+        .expect(rebuildable.rebuildCount)
+        .toBe(0)
+    })
+    .pipe(
+      Effect.provide(Layer.succeed(Bundle.Bundle, rebuildable)),
+      Effect.runPromise,
+    )
+})
+
+test.it("rebuilds on GET when Development is in context", () => {
+  const rebuildable = makeRebuildableBundle()
+
+  return Effect
+    .gen(function*() {
+      const runtime = yield* Effect.runtime<Bundle.Bundle>()
+      const routes = BundleRoute.make(Bundle.Bundle)
+      const tree = Route.map({ "/_bundle/:path+": routes })
+      const handles = Object.fromEntries(RouteHttp.walkHandles(tree, runtime))
+      const handler = handles["/_bundle/:path+"]
+
+      const client = Fetch.fromHandler(handler)
+      yield* client.get("http://localhost/_bundle/app-abc123.js")
+      yield* client.get("http://localhost/_bundle/app-abc123.js")
+
+      test
+        .expect(rebuildable.rebuildCount)
+        .toBe(2)
+    })
+    .pipe(
+      Effect.provide(Layer.succeed(Bundle.Bundle, rebuildable)),
+      Effect.provide(Development.layerTest),
+      Effect.runPromise,
+    )
+})
 
 test.it("supports custom mount path", () =>
   Effect


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #97

## Summary

`BundleRoute` was calling `bundle.rebuild()` on every `GET /_bundle/*` whenever `rebuild` was present, causing a full bundler rerun per asset — including in production.

This gates rebuild on `Development` being in context. In production, artifacts are served as-is and freshness comes from file watch + `BundleContext.events`.

## Changes

- Gate `bundle.rebuild()` on `Development.option` in `BundleRoute`
- Add tests covering rebuild-with-Development and no-rebuild-without-Development

## Test plan

- [x] `bun test test/bundler/BundleRoute.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

