### PR TITLE
Support trailing slash redirects as built-in middleware (#89)

### DIFF
--- a/src/Route.ts
+++ b/src/Route.ts
@@ -251,6 +251,9 @@ export {
 export {
   sse,
 } from "./internal/RouteSse.ts"
+export {
+  make as trailingSlashRedirect,
+} from "./internal/RouteTrailingSlash.ts"
 
 export class Routes extends Context.Tag("effect-start/Routes")<Routes, RouteMap.RouteMap>() {}
 

--- a/src/internal/RouteTrailingSlash.ts
+++ b/src/internal/RouteTrailingSlash.ts
@@ -1,0 +1,79 @@
+import * as Effect from "effect/Effect"
+import * as Entity from "../Entity.ts"
+import * as Route from "../Route.ts"
+
+export interface Options {
+  /**
+   * Whether the canonical form strips ("strip") or adds ("append") the
+   * trailing slash. Defaults to `"strip"`.
+   *
+   * The root path `/` is always left untouched regardless of mode, since it
+   * cannot be stripped any further.
+   */
+  readonly mode?: "strip" | "append"
+
+  /**
+   * Redirect status code. Defaults to `308` (Permanent Redirect), which
+   * preserves the original request method and body — important since this
+   * middleware also applies to non-GET requests. Use `301` if you need the
+   * traditional (method-downgrading) permanent redirect instead.
+   */
+  readonly status?: 301 | 308
+}
+
+function canonicalPathname(
+  pathname: string,
+  mode: "strip" | "append",
+): string | undefined {
+  if (pathname === "/") return undefined
+
+  const hasTrailingSlash = pathname.endsWith("/")
+
+  if (mode === "strip") {
+    return hasTrailingSlash ? pathname.slice(0, -1) : undefined
+  }
+
+  return hasTrailingSlash ? undefined : `${pathname}/`
+}
+
+export function make(options?: Options) {
+  const mode = options?.mode ?? "strip"
+  const status = options?.status ?? 308
+
+  return <D, SB, P extends Route.Route.Tuple>(
+    self: Route.RouteSet<D, SB, P>,
+  ): Route.RouteSet<
+    D,
+    SB,
+    [...P, Route.Route<{}, {}, unknown, never, Route.Request>]
+  > => {
+    const route = Route.make<{}, {}, unknown, never, Route.Request>((
+      _context,
+      next,
+    ) =>
+      Effect.gen(function*() {
+        const request = yield* Route.Request
+        const url = new URL(request.url)
+        const canonical = canonicalPathname(url.pathname, mode)
+
+        if (canonical === undefined) {
+          return yield* next
+        }
+
+        url.pathname = canonical
+        return Entity.make("", {
+          status,
+          headers: { location: url.pathname + url.search },
+        })
+      })
+    )
+
+    return Route.set(
+      [...Route.items(self), route] as [
+        ...P,
+        Route.Route<{}, {}, unknown, never, Route.Request>,
+      ],
+      Route.descriptor(self),
+    )
+  }
+}

--- a/test/RouteTrailingSlash.test.ts
+++ b/test/RouteTrailingSlash.test.ts
@@ -1,0 +1,154 @@
+import * as test from "bun:test"
+import * as Fetch from "effect-start/Fetch"
+import * as Route from "effect-start/Route"
+import * as RouteHttp from "effect-start/RouteHttp"
+import * as Effect from "effect/Effect"
+
+function makeHandler(options?: Parameters<typeof Route.trailingSlashRedirect>[0]) {
+  return Fetch.fromHandler(
+    RouteHttp.toWebHandler(
+      Route.use(Route.trailingSlashRedirect(options)).get(
+        Route.text("ok"),
+      ).post(Route.text("ok")),
+    ),
+  )
+}
+
+test.describe("Route.trailingSlashRedirect", () => {
+  test.describe("default (strip) mode", () => {
+    const client = makeHandler()
+
+    test.it("redirects a path with a trailing slash to its canonical form", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo/")
+
+          test
+            .expect(entity.status)
+            .toBe(308)
+          test
+            .expect(entity.headers["location"])
+            .toBe("/foo")
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("redirects nested paths with a trailing slash", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo/bar/")
+
+          test
+            .expect(entity.status)
+            .toBe(308)
+          test
+            .expect(entity.headers["location"])
+            .toBe("/foo/bar")
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("preserves the query string when redirecting", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo/?a=1&b=2")
+
+          test
+            .expect(entity.status)
+            .toBe(308)
+          test
+            .expect(entity.headers["location"])
+            .toBe("/foo?a=1&b=2")
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("passes through a path without a trailing slash", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo")
+
+          test
+            .expect(entity.status)
+            .toBe(200)
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("never redirects the root path", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/")
+
+          test
+            .expect(entity.status)
+            .toBe(200)
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("redirects non-GET requests, preserving method via 308", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.post("http://localhost/foo/")
+
+          test
+            .expect(entity.status)
+            .toBe(308)
+          test
+            .expect(entity.headers["location"])
+            .toBe("/foo")
+        })
+        .pipe(Effect.runPromise))
+  })
+
+  test.describe("append mode", () => {
+    const client = makeHandler({ mode: "append" })
+
+    test.it("redirects a bare path to add a trailing slash", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo")
+
+          test
+            .expect(entity.status)
+            .toBe(308)
+          test
+            .expect(entity.headers["location"])
+            .toBe("/foo/")
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("passes through a path that already has a trailing slash", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo/")
+
+          test
+            .expect(entity.status)
+            .toBe(200)
+        })
+        .pipe(Effect.runPromise))
+
+    test.it("never redirects the root path", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/")
+
+          test
+            .expect(entity.status)
+            .toBe(200)
+        })
+        .pipe(Effect.runPromise))
+  })
+
+  test.describe("custom status", () => {
+    const client = makeHandler({ status: 301 })
+
+    test.it("uses the configured redirect status code", () =>
+      Effect
+        .gen(function*() {
+          const entity = yield* client.get("http://localhost/foo/")
+
+          test
+            .expect(entity.status)
+            .toBe(301)
+        })
+        .pipe(Effect.runPromise))
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #89

## Summary

Adds a built-in trailing-slash redirect middleware, usable via `Route.use(Route.trailingSlashRedirect())`.

## Changes

- New `Route.trailingSlashRedirect` middleware (`strip` default, optional `append`)
- Default status 308 (preserves method/body); optional 301
- Root `/` is never redirected; query strings are preserved

## Test plan

- [x] `bun test test/RouteTrailingSlash.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

