### PR TITLE
Route.redirect: accept cookies and headers (#95)

### DIFF
--- a/src/Route.ts
+++ b/src/Route.ts
@@ -60,6 +60,7 @@ import * as Option from "effect/Option"
 import * as Pipeable from "effect/Pipeable"
 import * as Predicate from "effect/Predicate"
 import type { JSX } from "../src/jsx.ts"
+import * as Cookies from "./Cookies.ts"
 import * as Development from "./Development.ts"
 import * as Entity from "./Entity.ts"
 import * as Html from "./Html.ts"
@@ -187,9 +188,17 @@ export const bytes = RouteBody.build<Uint8Array, "bytes">({
  */
 export const handle = RouteBody.handle
 
+/**
+ * Redirects to the given URL. Accepts custom headers and cookies,
+ * e.g. to set a flash message or session cookie alongside the redirect.
+ */
 export function redirect<D, B, I extends Route.Tuple>(
   url: string | URL,
-  options?: { status?: 301 | 302 | 303 | 307 | 308 },
+  options?: {
+    status?: 301 | 302 | 303 | 307 | 308
+    headers?: Entity.Headers
+    cookies?: Cookies.Cookies
+  },
 ): (
   self: RouteSet<D, B, I>,
 ) => RouteSet<D, B, [...I, Route<{}, {}, "", never, never>]> {
@@ -199,7 +208,11 @@ export function redirect<D, B, I extends Route.Tuple>(
         Entity.make("", {
           status: options?.status ?? 302,
           headers: {
+            ...options?.headers,
             location: url instanceof URL ? url.href : url,
+            ...(options?.cookies && !Cookies.isEmpty(options.cookies)
+              ? { "set-cookie": Cookies.toSetCookieHeaders(options.cookies) }
+              : undefined),
           },
         }),
       ),

--- a/test/Route.test.tsx
+++ b/test/Route.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource effect-start */
 import * as test from "bun:test"
 import type * as Engine from "effect-start/datastar"
+import * as Cookies from "effect-start/Cookies"
 import * as Development from "effect-start/Development"
 import * as Entity from "effect-start/Entity"
 import * as Fetch from "effect-start/Fetch"
@@ -414,6 +415,125 @@ test.describe(Route.redirect, () => {
         test
           .expect(entity.headers["location"])
           .toBe("/time")
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("accepts cookies to set alongside the redirect", () =>
+    Effect
+      .gen(function*() {
+        const cookies = Cookies.unsafeSet(Cookies.empty, "session", "abc123")
+        const routes = Route.get(
+          Route.redirect("/", { cookies }),
+        )
+        const handler = RouteHttp.toWebHandler(routes)
+        const client = Fetch.fromHandler(handler)
+
+        const entity = yield* client.get("http://localhost/test")
+
+        test
+          .expect(entity.status)
+          .toBe(302)
+        test
+          .expect(entity.headers["location"])
+          .toBe("/")
+        test
+          .expect(entity.headers["set-cookie"])
+          .toBe("session=abc123")
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("accepts multiple cookies", () =>
+    Effect
+      .gen(function*() {
+        const cookies = Cookies.unsafeSetAll(Cookies.empty, [
+          ["session", "abc123"],
+          ["theme", "dark"],
+        ])
+        const routes = Route.get(
+          Route.redirect("/", { cookies }),
+        )
+        const handler = RouteHttp.toWebHandler(routes)
+
+        const response = yield* Effect.promise(() =>
+          Promise.resolve(handler(new Request("http://localhost/test")))
+        )
+
+        test
+          .expect(response.headers.getSetCookie())
+          .toEqual([
+            "session=abc123",
+            "theme=dark",
+          ])
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("ignores empty cookies", () =>
+    Effect
+      .gen(function*() {
+        const routes = Route.get(
+          Route.redirect("/", { cookies: Cookies.empty }),
+        )
+        const handler = RouteHttp.toWebHandler(routes)
+        const client = Fetch.fromHandler(handler)
+
+        const entity = yield* client.get("http://localhost/test")
+
+        test
+          .expect(entity.headers["set-cookie"])
+          .toBeUndefined()
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("accepts custom headers", () =>
+    Effect
+      .gen(function*() {
+        const routes = Route.get(
+          Route.redirect("/", { headers: { "x-flash": "welcome" } }),
+        )
+        const handler = RouteHttp.toWebHandler(routes)
+        const client = Fetch.fromHandler(handler)
+
+        const entity = yield* client.get("http://localhost/test")
+
+        test
+          .expect(entity.headers["x-flash"])
+          .toBe("welcome")
+        test
+          .expect(entity.headers["location"])
+          .toBe("/")
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("merges set-cookie from a wrapping layer with redirect cookies", () =>
+    Effect
+      .gen(function*() {
+        const layerCookies = Cookies.unsafeSet(Cookies.empty, "a", "1")
+        const redirectCookies = Cookies.unsafeSet(Cookies.empty, "b", "2")
+
+        const layer = Route.make<{}, {}, unknown>((_context, next) =>
+          Effect.map(next, (entity) =>
+            Entity.merge(entity, {
+              headers: {
+                "set-cookie": Cookies.toSetCookieHeaders(layerCookies),
+              },
+            }))
+        )
+
+        const routes = Route.use(layer).get(
+          Route.redirect("/", { cookies: redirectCookies }),
+        )
+        const handler = RouteHttp.toWebHandler(routes)
+
+        const response = yield* Effect.promise(() =>
+          Promise.resolve(handler(new Request("http://localhost/test")))
+        )
+
+        test
+          .expect(response.headers.getSetCookie())
+          .toEqual([
+            "a=1",
+            "b=2",
+          ])
       })
       .pipe(Effect.runPromise))
 })

--- a/test/Route.test.tsx
+++ b/test/Route.test.tsx
@@ -510,16 +510,21 @@ test.describe(Route.redirect, () => {
         const layerCookies = Cookies.unsafeSet(Cookies.empty, "a", "1")
         const redirectCookies = Cookies.unsafeSet(Cookies.empty, "b", "2")
 
-        const layer = Route.make<{}, {}, unknown>((_context, next) =>
-          Effect.map(next, (entity) =>
-            Entity.merge(entity, {
-              headers: {
-                "set-cookie": Cookies.toSetCookieHeaders(layerCookies),
-              },
-            }))
-        )
+        const withLayerCookie = <D, B, I extends Route.Route.Tuple>(
+          self: Route.RouteSet<D, B, I>,
+        ) => {
+          const route = Route.make<{}, {}, unknown>((_context, next) =>
+            Effect.map(next, (entity) =>
+              Entity.merge(entity, {
+                headers: {
+                  "set-cookie": Cookies.toSetCookieHeaders(layerCookies),
+                },
+              }))
+          )
+          return Route.set([...Route.items(self), route], Route.descriptor(self))
+        }
 
-        const routes = Route.use(layer).get(
+        const routes = Route.use(withLayerCookie).get(
           Route.redirect("/", { cookies: redirectCookies }),
         )
         const handler = RouteHttp.toWebHandler(routes)
@@ -531,8 +536,8 @@ test.describe(Route.redirect, () => {
         test
           .expect(response.headers.getSetCookie())
           .toEqual([
-            "a=1",
             "b=2",
+            "a=1",
           ])
       })
       .pipe(Effect.runPromise))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #95

## Summary

`Route.redirect` previously only set `location` (and optional `status`). Use cases that need `set-cookie` on redirects had to drop down to raw `Entity.make`.

## Changes

- Extend `Route.redirect` options with `cookies?: Cookies.Cookies` and `headers?: Entity.Headers`
- Serialize cookies via `Cookies.toSetCookieHeaders`
- Tests for single/multiple cookies, empty cookies, custom headers, and merge with wrapping layers

## Test plan

- [x] `bun test test/Route.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

