### PR TITLE
Route.link: encode array searchParams as repeated keys (#92)

### DIFF
--- a/src/internal/RouteLink.ts
+++ b/src/internal/RouteLink.ts
@@ -33,7 +33,7 @@ export function link<
   // Substitute path params, deleting used keys so the rest become search params
   const remaining = { ...args[1] } as Record<
     string,
-    string | number | undefined
+    string | number | ReadonlyArray<string | number> | undefined
   >
   const result = path.replace(
     /\/:(\w+)([?*+])?/g,
@@ -50,7 +50,13 @@ export function link<
 
   const search = new URLSearchParams()
   for (const key in remaining) {
-    if (remaining[key] != null) search.set(key, String(remaining[key]))
+    const value = remaining[key]
+    if (value == null) continue
+    if (Array.isArray(value)) {
+      for (const item of value) if (item != null) search.append(key, String(item))
+    } else {
+      search.set(key, String(value))
+    }
   }
   const qs = search.toString()
   return qs ? result + "?" + qs : result

--- a/test/Route.test.tsx
+++ b/test/Route.test.tsx
@@ -863,6 +863,40 @@ test.describe("Route.link", () => {
     Route.link<R>("/:owner/:repo/issues", { owner: "a", repo: "b", state: 123 })
   })
 
+  test.it("array search params produce repeated entries", () => {
+    const routes = Route.get(
+      Route.schemaSearchParams({
+        tags: Schema.Array(Schema.String),
+      }),
+      Route.html(""),
+    )
+
+    type R = { "/posts": [() => Promise<{ default: typeof routes }>] }
+
+    test
+      .expect(Route.link<R>("/posts", { tags: ["a", "b", "c"] }))
+      .toBe(
+        "/posts?tags=a&tags=b&tags=c",
+      )
+  })
+
+  test.it("empty array search params produce no query string", () => {
+    const routes = Route.get(
+      Route.schemaSearchParams({
+        tags: Schema.Array(Schema.String),
+      }),
+      Route.html(""),
+    )
+
+    type R = { "/posts": [() => Promise<{ default: typeof routes }>] }
+
+    test
+      .expect(Route.link<R>("/posts", { tags: [] }))
+      .toBe(
+        "/posts",
+      )
+  })
+
   test.it("type: optional search params from schema", () => {
     const routes = Route.get(
       Route.schemaSearchParams({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #92

## Summary

`Route.link` already supported search params, including typed `schemaSearchParams`. Array values were incorrectly stringified instead of encoded as repeated query keys (matching how decode already handles them).

## Changes

- Encode array search param values as repeated `key=value` entries
- Regression tests for array and empty-array cases

## Test plan

- [x] `bun test test/Route.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

