### PR TITLE
Add Start.export for serverless environments (#69)

### DIFF
--- a/src/Start.ts
+++ b/src/Start.ts
@@ -1,7 +1,11 @@
+import * as Context from "effect/Context"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as Function from "effect/Function"
 import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Runtime from "effect/Runtime"
+import * as Scope from "effect/Scope"
 import * as BunRuntime from "./bun/BunRuntime.ts"
 import * as BunServer from "./bun/BunServer.ts"
 import * as BundleRoute from "./bundler/BundleRoute.ts"
@@ -9,6 +13,10 @@ import type * as ChildProcess from "./ChildProcess.ts"
 import * as Development from "./Development.ts"
 import type * as FileSystem from "./FileSystem.ts"
 import * as LayerExtra from "./internal/LayerExtra.ts"
+import * as PathPattern from "./internal/PathPattern.ts"
+import * as RouteMap from "./internal/RouteMap.ts"
+import * as Route from "./Route.ts"
+import * as RouteHttp from "./RouteHttp.ts"
 
 /**
  * Builds layers in the given order, wiring their dependencies automatically.
@@ -149,4 +157,125 @@ export function runMain(meta: ImportMeta): void {
       `Start.runMain: ${meta.url} is not an entrypoint, skipping.`,
     )
   }
+}
+
+export type FetchHandler = (
+  request: Request,
+  ...args: ReadonlyArray<unknown>
+) => Promise<Response>
+
+/**
+ * Lets a layer turn the extra arguments a platform passes to `fetch` (e.g.
+ * Cloudflare Workers' `env` and `ctx`) into request-scoped context that
+ * route handlers can pull services from.
+ */
+export interface FetchAdapter {
+  readonly context: (args: ReadonlyArray<unknown>) => Context.Context<never>
+}
+
+export const FetchAdapter = Context.GenericTag<FetchAdapter>(
+  "effect-start/Start/FetchAdapter",
+)
+
+/**
+ * Builds a `FetchAdapter` layer from a function mapping the extra arguments
+ * passed to the exported `fetch` into a `Context` of services.
+ *
+ * @example
+ * ```ts
+ * // Cloudflare Workers call fetch(request, env, ctx)
+ * class CloudflareEnv extends Context.Tag("CloudflareEnv")<CloudflareEnv, Env>() {}
+ *
+ * Start.layerFetchAdapter((env: Env) => Context.make(CloudflareEnv, env))
+ * ```
+ */
+export function layerFetchAdapter(
+  toContext: (...args: ReadonlyArray<any>) => Context.Context<never>,
+): Layer.Layer<FetchAdapter> {
+  return Layer.succeed(FetchAdapter, {
+    context: (args) => toContext(...args),
+  })
+}
+
+function dispatcher(
+  routeMap: RouteMap.RouteMap,
+  runtime: Runtime.Runtime<any>,
+): (request: Request) => Promise<Response> {
+  const handlers = Array.from(RouteHttp.walkHandles(routeMap, runtime))
+  return (request) => {
+    const pathname = decodeURI(new URL(request.url).pathname)
+    for (const [path, handler] of handlers) {
+      if (PathPattern.match(path, pathname) !== null) {
+        return handler(request) as Promise<Response>
+      }
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }))
+  }
+}
+
+/**
+ * Like `pack`, but instead of starting a server, resolves to a `fetch`
+ * handler — the shape serverless platforms (Cloudflare Workers, Deno Deploy)
+ * expect.
+ *
+ * Unlike `serve`, this does not depend on `BunServer`, `BunRuntime`, or
+ * `layerDev` (which pulls in Bun/Node-only services), so the resulting
+ * `fetch` handler stays usable outside of Bun. Layers passed in must
+ * satisfy their own dependencies, same as `pack`.
+ *
+ * A layer can provide `FetchAdapter` to accept extra arguments (beyond
+ * `request`) and turn them into request-scoped context.
+ *
+ * @example
+ * ```ts
+ * export default { fetch: await Start.export(Route.layer(routes)) }
+ * ```
+ */
+export function export_<
+  const Layers extends readonly [Layer.Layer.Any, ...Array<Layer.Layer.Any>],
+>(
+  ...layers: LayerExtra.Unordered<Layers>
+): Promise<FetchHandler> {
+  const appLayer = Layer.scopedContext(
+    LayerExtra.buildUnordered(layers as unknown as Layers),
+  ) as Layer.Layer<
+    LayerExtra.LayersSuccess<Layers>,
+    LayerExtra.LayersError<Layers>,
+    never
+  >
+
+  const composed = Function.pipe(
+    BundleRoute.layer(),
+    Layer.provideMerge(appLayer),
+  )
+
+  return Effect.runPromise(
+    Effect.gen(function*() {
+      const scope = yield* Scope.make()
+      const runtime = yield* Layer.toRuntime(composed).pipe(
+        Effect.provideService(Scope.Scope, scope),
+      )
+      const routeMap = Context.getOption(runtime.context, Route.Routes).pipe(
+        Option.getOrElse(() => RouteMap.make({})),
+      )
+      const dispatch = dispatcher(routeMap, runtime)
+      const adapter = Context.getOption(runtime.context, FetchAdapter)
+
+      if (Option.isNone(adapter)) {
+        return dispatch as FetchHandler
+      }
+
+      return ((request: Request, ...args: ReadonlyArray<unknown>) => {
+        const requestRuntime = Runtime.updateContext(
+          runtime,
+          (ctx) => Context.merge(ctx, adapter.value.context(args)),
+        )
+        return dispatcher(routeMap, requestRuntime)(request)
+      }) as FetchHandler
+    }),
+  )
+}
+
+export {
+  export_ as export,
 }

--- a/test/Start.test.ts
+++ b/test/Start.test.ts
@@ -1,4 +1,5 @@
 import * as test from "bun:test"
+import * as Route from "effect-start/Route"
 import * as Start from "effect-start/Start"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -137,6 +138,109 @@ test.describe(Start.pack, () => {
         Effect.provide(AppLayer),
         Effect.runPromise,
       )
+  })
+})
+
+test.describe("Start.export", () => {
+  test.test("routes a matching request", async () => {
+    const fetch = await Start.export(
+      Route.layer({
+        "/hello": Route.get(Route.text("hello world")),
+      }),
+    )
+
+    const response = await fetch(new Request("http://localhost/hello"))
+
+    test.expect(response.status).toBe(200)
+    test.expect(await response.text()).toBe("hello world")
+  })
+
+  test.test("returns 404 for an unmatched path", async () => {
+    const fetch = await Start.export(
+      Route.layer({
+        "/hello": Route.get(Route.text("hello world")),
+      }),
+    )
+
+    const response = await fetch(new Request("http://localhost/missing"))
+
+    test.expect(response.status).toBe(404)
+  })
+
+  test.test("resolves services from layers regardless of order, like pack", async () => {
+    class Config extends Context.Tag("Config")<Config, { readonly name: string }>() {}
+    class Greeter extends Context.Tag("Greeter")<
+      Greeter,
+      { readonly greet: () => Effect.Effect<string> }
+    >() {}
+
+    const GreeterLive = Layer.effect(
+      Greeter,
+      Effect.gen(function*() {
+        const config = yield* Config
+        return { greet: () => Effect.succeed(`hello, ${config.name}`) }
+      }),
+    )
+    const ConfigLive = Layer.succeed(Config, { name: "world" })
+
+    const fetch = await Start.export(
+      Route.layer({
+        "/greet": Route.get(
+          Route.text(function*() {
+            const greeter = yield* Greeter
+            return yield* greeter.greet()
+          }),
+        ),
+      }),
+      // GreeterLive is listed before its dependency ConfigLive, same as pack.
+      GreeterLive,
+      ConfigLive,
+    )
+
+    const response = await fetch(new Request("http://localhost/greet"))
+
+    test.expect(await response.text()).toBe("hello, world")
+  })
+
+  test.test("FetchAdapter turns extra fetch arguments into request context", async () => {
+    // Services that a FetchAdapter fills in per-request are marked with
+    // Route.IntrinsicService so routes can depend on them without a Layer
+    // providing them upfront, the same way Route.Request is provided.
+    class CloudflareEnv extends Context.Tag("CloudflareEnv")<
+      CloudflareEnv,
+      { readonly greeting: string }
+    >() {
+      declare readonly [Route.IntrinsicService]: never
+    }
+
+    const fetch = await Start.export(
+      Route.layer({
+        "/greet": Route.get(
+          Route.text(function*() {
+            const env = yield* CloudflareEnv
+            return env.greeting
+          }),
+        ),
+      }),
+      Start.layerFetchAdapter((env: { greeting: string }) => Context.make(CloudflareEnv, env)),
+    )
+
+    const response = await fetch(
+      new Request("http://localhost/greet"),
+      { greeting: "hi from cloudflare" },
+    )
+
+    test.expect(await response.text()).toBe("hi from cloudflare")
+  })
+
+  test.test("without a FetchAdapter the handler only takes a request", async () => {
+    const fetch = await Start.export(
+      Route.layer({
+        "/hello": Route.get(Route.text("hello world")),
+      }),
+    )
+
+    test.expect(fetch.length).toBe(1)
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #69

## Summary

`Start.serve` owns the full Bun server lifecycle. Serverless platforms expect a `fetch` handler export instead.

## Changes

- `Start.export(...layers)` → `Promise<(request: Request, ...args) => Promise<Response>>`
- Does not merge `layerDev()` so the handler stays free of Bun/Node-only deps
- `Start.FetchAdapter` / `Start.layerFetchAdapter` for Cloudflare-style `fetch(req, env, ctx)` → request-scoped Context

## Test plan

- [x] `bun test test/Start.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

