### PR TITLE
Keep handler scope open for native Response bodies (#93)

### DIFF
--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -91,6 +91,9 @@ function getText(
   self: Entity<unknown, unknown>,
 ): Effect.Effect<string, ParseResult.ParseError | unknown> {
   const v = self.body
+  if (v instanceof Response) {
+    return fromResponse(v).text
+  }
   if (StreamExtra.isStream(v)) {
     return Stream.mkString(
       Stream.decodeText(v as Stream.Stream<Uint8Array, unknown, never>),
@@ -102,6 +105,9 @@ function getText(
       (inner): Effect.Effect<string, ParseResult.ParseError | unknown> => {
         if (isEntity(inner)) {
           return inner.text
+        }
+        if (inner instanceof Response) {
+          return fromResponse(inner).text
         }
         if (typeof inner === "string") {
           return Effect.succeed(inner)
@@ -128,6 +134,9 @@ function getJson(
   self: Entity<unknown, unknown>,
 ): Effect.Effect<unknown, ParseResult.ParseError | unknown> {
   const v = self.body
+  if (v instanceof Response) {
+    return fromResponse(v).json
+  }
   if (StreamExtra.isStream(v)) {
     return Effect.flatMap(getText(self), parseJson)
   }
@@ -137,6 +146,9 @@ function getJson(
       (inner): Effect.Effect<unknown, ParseResult.ParseError | unknown> => {
         if (isEntity(inner)) {
           return inner.json
+        }
+        if (inner instanceof Response) {
+          return fromResponse(inner).json
         }
         if (isDirectJson(inner)) {
           return Effect.succeed(inner)
@@ -167,6 +179,9 @@ function getBytes(
   self: Entity<unknown, unknown>,
 ): Effect.Effect<Uint8Array, ParseResult.ParseError | unknown> {
   const v = self.body
+  if (v instanceof Response) {
+    return fromResponse(v).bytes
+  }
   if (StreamExtra.isStream(v)) {
     return Stream.runFold(
       v as Stream.Stream<Uint8Array, unknown, never>,
@@ -180,6 +195,9 @@ function getBytes(
       (inner): Effect.Effect<Uint8Array, ParseResult.ParseError | unknown> => {
         if (isEntity(inner)) {
           return inner.bytes
+        }
+        if (inner instanceof Response) {
+          return fromResponse(inner).bytes
         }
         if (inner instanceof Uint8Array) {
           return Effect.succeed(inner)
@@ -220,6 +238,9 @@ function getStream(
   self: Entity<unknown, unknown>,
 ): Stream.Stream<unknown, unknown> {
   const v = self.body
+  if (v instanceof Response) {
+    return fromResponse(v).stream
+  }
   if (StreamExtra.isStream(v)) {
     return v as Stream.Stream<unknown, unknown, never>
   }
@@ -228,6 +249,9 @@ function getStream(
       Effect.map(v as Effect.Effect<unknown, unknown, never>, (inner) => {
         if (isEntity(inner)) {
           return inner.stream
+        }
+        if (inner instanceof Response) {
+          return fromResponse(inner).stream
         }
         return Stream.fromEffect(getBytes(make(inner)))
       }),

--- a/src/internal/RouteBody.ts
+++ b/src/internal/RouteBody.ts
@@ -28,6 +28,8 @@ type HandlerReturn<A, Value = A> =
   | Entity.Entity<Stream.Stream<Value, any, any>, any>
   // support returing bytes from text/json/etc
   | Entity.Entity<Uint8Array, any>
+  // scope is extended until the response body finishes streaming
+  | Response
   | ((self: Route.RouteSet.Any) => Route.RouteSet.Any)
 
 type HandlerFunction<B, A, E, R, Value = A> = (
@@ -125,6 +127,9 @@ function normalizeToEntity(value: unknown): Effect.Effect<Entity.Entity<any>> {
   }
   if (Entity.isEntity(value)) {
     return Effect.succeed(value)
+  }
+  if (value instanceof Response) {
+    return Effect.succeed(Entity.fromResponse(value))
   }
   return Effect.succeed(Entity.make(value, { status: 200 }))
 }

--- a/test/RouteHttp.test.ts
+++ b/test/RouteHttp.test.ts
@@ -2,7 +2,9 @@ import * as test from "bun:test"
 import * as Development from "effect-start/Development"
 import * as Entity from "effect-start/Entity"
 import * as Fetch from "effect-start/Fetch"
+import * as FileSystem from "effect-start/FileSystem"
 import * as Multipart from "effect-start/Multipart"
+import { NodeFileSystem } from "effect-start/node"
 import * as Route from "effect-start/Route"
 import * as RouteHttp from "effect-start/RouteHttp"
 import { TestLogger } from "effect-start/testing"
@@ -2916,6 +2918,32 @@ test.describe("stream response scope", () => {
       })
       .pipe(Effect.runPromise))
 
+  test.it("keeps a temp file alive until a plain stream response finishes reading it", () =>
+    Effect
+      .gen(function*() {
+        const fs = yield* FileSystem.FileSystem
+        const runtime = yield* Effect.runtime<FileSystem.FileSystem>()
+        const handler = RouteHttp.toWebHandlerRuntime(runtime)(
+          Route.get(
+            Route.handle(() =>
+              Effect.gen(function*() {
+                const path = yield* fs.makeTempFileScoped()
+                yield* fs.writeFileString(path, "temp file contents")
+                return fs.stream(path)
+              })
+            ),
+          ),
+        )
+
+        const response = yield* Effect.promise(() => Promise.resolve(handler(new Request("http://localhost/file"))))
+        const text = yield* Effect.promise(() => response.text())
+
+        test
+          .expect(text)
+          .toBe("temp file contents")
+      })
+      .pipe(Effect.provide(NodeFileSystem.layer), Effect.runPromise))
+
   test.it("keeps fibers forked in the request scope alive while streaming", () =>
     Effect
       .gen(function*() {
@@ -2989,6 +3017,126 @@ test.describe("stream response scope", () => {
         test
           .expect(text)
           .toContain("data: /events")
+      })
+      .pipe(Effect.runPromise))
+})
+
+test.describe("native Response bodies", () => {
+  test.it("supports returning a raw Response from a handler, preserving its status and headers", () =>
+    Effect
+      .gen(function*() {
+        const handler = RouteHttp.toWebHandler(
+          Route.get(
+            Route.handle(() =>
+              Effect.succeed(
+                new Response("raw response body", {
+                  status: 201,
+                  headers: { "x-custom": "yes" },
+                }),
+              )
+            ),
+          ),
+        )
+
+        const response = yield* Effect.promise(() => Promise.resolve(handler(new Request("http://localhost/raw"))))
+
+        test
+          .expect(response.status)
+          .toBe(201)
+        test
+          .expect(response.headers.get("x-custom"))
+          .toBe("yes")
+        test
+          .expect(yield* Effect.promise(() => response.text()))
+          .toBe("raw response body")
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("keeps the handler scope open until a raw Response body finishes streaming", () =>
+    Effect
+      .gen(function*() {
+        let released = false
+
+        const handler = RouteHttp.toWebHandler(
+          Route.get(
+            Route.handle(() =>
+              Effect.gen(function*() {
+                yield* Effect.acquireRelease(
+                  Effect.void,
+                  () =>
+                    Effect.sync(() => {
+                      released = true
+                    }),
+                )
+                const body = new ReadableStream({
+                  start(controller) {
+                    controller.enqueue(new TextEncoder().encode("chunk"))
+                    controller.close()
+                  },
+                })
+                return new Response(body)
+              })
+            ),
+          ),
+        )
+
+        const response = yield* Effect.promise(() => Promise.resolve(handler(new Request("http://localhost/raw"))))
+
+        test
+          .expect(released)
+          .toBe(false)
+
+        const text = yield* Effect.promise(() => response.text())
+
+        test
+          .expect(text)
+          .toBe("chunk")
+        test
+          .expect(released)
+          .toBe(true)
+      })
+      .pipe(Effect.runPromise))
+
+  test.it("closes the handler scope when the client cancels a raw Response body", () =>
+    Effect
+      .gen(function*() {
+        let released = false
+
+        const handler = RouteHttp.toWebHandler(
+          Route.get(
+            Route.handle(() =>
+              Effect.gen(function*() {
+                yield* Effect.acquireRelease(
+                  Effect.void,
+                  () =>
+                    Effect.sync(() => {
+                      released = true
+                    }),
+                )
+                const body = new ReadableStream({
+                  start(controller) {
+                    controller.enqueue(new TextEncoder().encode("first"))
+                  },
+                })
+                return new Response(body)
+              })
+            ),
+          ),
+        )
+
+        const response = yield* Effect.promise(() => Promise.resolve(handler(new Request("http://localhost/raw"))))
+        const reader = response.body!.getReader()
+        yield* Effect.promise(() => reader.read())
+
+        test
+          .expect(released)
+          .toBe(false)
+
+        yield* Effect.promise(() => reader.cancel())
+
+        test
+          .expect(released)
+          .toBe(true)
       })
       .pipe(Effect.runPromise))
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #93

## Summary

Handler scopes already stayed open for Effect Stream bodies until the response finished. Returning a native `Response` (e.g. wrapping `Bun.file` or a `ReadableStream`) crashed with a ParseError and did not participate in deferred scope ownership.

## Changes

- Normalize `Response` returns via `Entity.fromResponse` so they flow through existing stream scope ownership
- Recognize nested `Response` bodies in Entity getters
- Regression tests for temp-file streaming and native Response scope lifetime

## Test plan

- [x] `bun test test/RouteHttp.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

