### PR TITLE
Unify bundler plugins to esbuild-shaped Plugin API (#49)

### DIFF
--- a/examples/SimpleBundle.tsx
+++ b/examples/SimpleBundle.tsx
@@ -1,6 +1,6 @@
 import { Context, Layer, Schema } from "effect"
 import { Bundle, Route, Start } from "effect-start"
-import { BunBundle } from "effect-start/bun"
+import { BunBundle, BunPlugin } from "effect-start/bun"
 import { TailwindPlugin } from "effect-start/tailwind"
 
 class SomeService extends Context.Tag("SomeService")<SomeService, {}>() {}
@@ -62,7 +62,7 @@ export default Start.pack(
       import.meta.resolve("./client.js"),
       import.meta.resolve("./client.css"),
     ],
-    plugins: [TailwindPlugin.make()],
+    plugins: [BunPlugin.toBunPlugin(TailwindPlugin.make())],
   }),
   Route.layer(routes),
 )

--- a/examples/chat/src/server.ts
+++ b/examples/chat/src/server.ts
@@ -1,5 +1,5 @@
 import { Development, FileRouter, Start } from "effect-start"
-import { BunBundle, BunServer } from "effect-start/bun"
+import { BunBundle, BunPlugin, BunServer } from "effect-start/bun"
 import { Studio } from "effect-start/studio"
 import { TailwindPlugin } from "effect-start/tailwind"
 
@@ -9,7 +9,7 @@ export default Start.pack(
   FileRouter.layer(),
   BunBundle.layer({
     entrypoints: [import.meta.resolve("./app.css"), "effect-start/datastar"],
-    plugins: [TailwindPlugin.make()],
+    plugins: [BunPlugin.toBunPlugin(TailwindPlugin.make())],
   }),
   Start.layerDev(),
   BunServer.layer(),

--- a/examples/gh1/src/server.ts
+++ b/examples/gh1/src/server.ts
@@ -1,5 +1,5 @@
 import { Development, FileRouter, Start } from "effect-start"
-import { BunBundle } from "effect-start/bun"
+import { BunBundle, BunPlugin } from "effect-start/bun"
 import { Studio } from "effect-start/studio"
 import { TailwindPlugin } from "effect-start/tailwind"
 
@@ -9,7 +9,7 @@ export default Start.pack(
   FileRouter.layer(),
   BunBundle.layer({
     entrypoints: [import.meta.resolve("./app.css"), "effect-start/datastar"],
-    plugins: [TailwindPlugin.make()],
+    plugins: [BunPlugin.toBunPlugin(TailwindPlugin.make())],
   }),
   Start.layerDev(),
 )

--- a/src/bun/BunPlugin.ts
+++ b/src/bun/BunPlugin.ts
@@ -1,0 +1,29 @@
+import type * as Bun from "bun"
+import type * as Plugin from "../bundler/Plugin.ts"
+
+/**
+ * Adapts a bundler-agnostic {@link Plugin.Plugin} to a {@link Bun.BunPlugin}.
+ *
+ * Bun's `onResolve`/`onLoad` builder is already shaped like the generic
+ * plugin interface (including a native `defer()`), so this is a thin
+ * pass-through rather than a behavioral shim.
+ */
+export function toBunPlugin(
+  plugin: Plugin.Plugin,
+  opts?: { readonly target?: Bun.BunPlugin["target"] },
+): Bun.BunPlugin {
+  return {
+    name: plugin.name,
+    target: opts?.target,
+    setup(builder) {
+      return plugin.setup({
+        onResolve(options, callback) {
+          builder.onResolve(options, (args) => callback(args) as any)
+        },
+        onLoad(options, callback) {
+          builder.onLoad(options, (args) => callback(args) as any)
+        },
+      })
+    },
+  }
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,6 +1,7 @@
 export * as BunBundle from "./BunBundle.ts"
 export * as BunChildProcessSpawner from "./BunChildProcessSpawner.ts"
 export * as BunImportTrackerPlugin from "./BunImportTrackerPlugin.ts"
+export * as BunPlugin from "./BunPlugin.ts"
 export * as BunRoute from "./BunRoute.ts"
 export * as BunServer from "./BunServer.ts"
 export * as BunSocket from "./BunSocket.ts"

--- a/src/bundler/Plugin.ts
+++ b/src/bundler/Plugin.ts
@@ -1,0 +1,92 @@
+/**
+ * Bundler-agnostic plugin shape, modeled after esbuild's `onResolve`/`onLoad`
+ * plugin interface. Bun, esbuild, and (via a thin adapter) Rolldown can all
+ * run a plugin written against these types.
+ *
+ * A plugin built with this module has no bundler-specific dependency. To run
+ * it, convert it with the adapter for the target bundler:
+ * - `bun/BunPlugin.ts` -> `Bun.build({ plugins: [...] })`
+ * - `esbuild/EsbuildPlugin.ts` -> `esbuild.build({ plugins: [...] })`
+ * - `rolldown/RolldownPlugin.ts` -> `rolldown.build({ plugins: [...] })`
+ */
+
+export type Loader =
+  | "js"
+  | "jsx"
+  | "ts"
+  | "tsx"
+  | "css"
+  | "json"
+  | "text"
+  | "base64"
+  | "dataurl"
+  | "file"
+  | "binary"
+  | "copy"
+  | "empty"
+  | "object"
+
+export interface OnResolveOptions {
+  readonly filter: RegExp
+  readonly namespace?: string
+}
+
+export interface OnLoadOptions {
+  readonly filter: RegExp
+  readonly namespace?: string
+}
+
+export interface OnResolveArgs {
+  readonly path: string
+  readonly importer: string
+  readonly namespace: string
+  readonly resolveDir: string
+  readonly kind: string
+  readonly pluginData?: unknown
+}
+
+export interface OnResolveResult {
+  path?: string
+  namespace?: string
+  external?: boolean
+  pluginData?: unknown
+}
+
+export interface OnLoadArgs {
+  readonly path: string
+  readonly namespace: string
+  readonly pluginData?: unknown
+  /**
+   * Defer this callback until every module reachable at the current point in
+   * the build has resolved and loaded, then resume. Native on Bun; emulated
+   * on adapters (esbuild, Rolldown) by tracking in-flight `onLoad` calls, so
+   * it approximates "wait for currently-discoverable siblings" rather than
+   * Bun's exact "wait for the whole parse pass" guarantee.
+   */
+  readonly defer: () => Promise<void>
+}
+
+export interface OnLoadResult {
+  contents?: string | Uint8Array
+  loader?: Loader
+  resolveDir?: string
+  pluginData?: unknown
+}
+
+export type OnResolveCallback = (
+  args: OnResolveArgs,
+) => OnResolveResult | undefined | null | Promise<OnResolveResult | undefined | null>
+
+export type OnLoadCallback = (
+  args: OnLoadArgs,
+) => OnLoadResult | undefined | Promise<OnLoadResult | undefined>
+
+export interface PluginBuild {
+  onResolve(options: OnResolveOptions, callback: OnResolveCallback): void
+  onLoad(options: OnLoadOptions, callback: OnLoadCallback): void
+}
+
+export interface Plugin {
+  readonly name: string
+  readonly setup: (build: PluginBuild) => void | Promise<void>
+}

--- a/src/bundler/internal/DeferredLoad.ts
+++ b/src/bundler/internal/DeferredLoad.ts
@@ -1,0 +1,49 @@
+/**
+ * Emulates Bun's `onLoad` `defer()` on bundlers that don't support it
+ * natively (esbuild, Rolldown). A deferring call stops counting as "active"
+ * and waits until every other `onLoad` call tracked by the same tracker has
+ * settled, then every waiter resumes together.
+ *
+ * This approximates, but doesn't exactly match, Bun's guarantee that a
+ * deferred callback resumes only after the *entire* parse pass completes: it
+ * resumes once every `onLoad` call that was active through the same tracker
+ * has settled, which depends on how much of the module graph the bundler has
+ * discovered by that point.
+ */
+export interface DeferredLoadTracker {
+  readonly wrapLoad: <A>(run: () => Promise<A>) => Promise<A>
+  readonly defer: () => Promise<void>
+}
+
+export function makeDeferredLoadTracker(): DeferredLoadTracker {
+  let active = 0
+  let waiters: Array<() => void> = []
+
+  const release = () => {
+    if (active > 0 || waiters.length === 0) return
+    const toRelease = waiters
+    waiters = []
+    active += toRelease.length
+    for (const resolve of toRelease) resolve()
+  }
+
+  const wrapLoad = async <A>(run: () => Promise<A>): Promise<A> => {
+    active++
+    try {
+      return await run()
+    } finally {
+      active--
+      release()
+    }
+  }
+
+  const defer = () => {
+    active--
+    return new Promise<void>((resolve) => {
+      waiters.push(resolve)
+      release()
+    })
+  }
+
+  return { wrapLoad, defer }
+}

--- a/src/esbuild/EsbuildPlugin.ts
+++ b/src/esbuild/EsbuildPlugin.ts
@@ -1,0 +1,36 @@
+import type * as esbuild from "esbuild"
+import * as DeferredLoad from "../bundler/internal/DeferredLoad.ts"
+import type * as Plugin from "../bundler/Plugin.ts"
+
+/**
+ * Adapts a bundler-agnostic {@link Plugin.Plugin} to an {@link esbuild.Plugin}.
+ *
+ * esbuild's plugin interface already matches `onResolve`/`onLoad` shape-wise,
+ * but has no `defer()` — this synthesizes one via {@link DeferredLoad}.
+ */
+export function toEsbuildPlugin(plugin: Plugin.Plugin): esbuild.Plugin {
+  const tracker = DeferredLoad.makeDeferredLoadTracker()
+
+  return {
+    name: plugin.name,
+    setup(build) {
+      return plugin.setup({
+        onResolve(options, callback) {
+          build.onResolve(options, (args) => callback(args) as any)
+        },
+        onLoad(options, callback) {
+          build.onLoad(
+            options,
+            (args) =>
+              tracker.wrapLoad(async () =>
+                callback({
+                  ...args,
+                  defer: tracker.defer,
+                }) as any
+              ),
+          )
+        },
+      })
+    },
+  }
+}

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -1,1 +1,2 @@
 export * as EsbuildBundle from "./EsbuildBundle.ts"
+export * as EsbuildPlugin from "./EsbuildPlugin.ts"

--- a/src/rolldown/RolldownPlugin.ts
+++ b/src/rolldown/RolldownPlugin.ts
@@ -1,0 +1,88 @@
+import * as NPath from "node:path"
+import type * as rolldown from "rolldown"
+import * as DeferredLoad from "../bundler/internal/DeferredLoad.ts"
+import type * as Plugin from "../bundler/Plugin.ts"
+
+/**
+ * Adapts a bundler-agnostic {@link Plugin.Plugin} to a Rollup-shaped
+ * {@link rolldown.Plugin}. Rolldown has no `onResolve`/`onLoad` — this maps
+ * onto its `resolveId`/`load` hooks and, like the esbuild adapter, synthesizes
+ * `defer()` via {@link DeferredLoad}.
+ */
+export function toRolldownPlugin(plugin: Plugin.Plugin): rolldown.Plugin {
+  const tracker = DeferredLoad.makeDeferredLoadTracker()
+  const resolveHandlers: Array<{ options: Plugin.OnResolveOptions; callback: Plugin.OnResolveCallback }> = []
+  const loadHandlers: Array<{ options: Plugin.OnLoadOptions; callback: Plugin.OnLoadCallback }> = []
+
+  plugin.setup({
+    onResolve(options, callback) {
+      resolveHandlers.push({ options, callback })
+    },
+    onLoad(options, callback) {
+      loadHandlers.push({ options, callback })
+    },
+  })
+
+  return {
+    name: plugin.name,
+    async resolveId(source, importer, extraOptions) {
+      for (const { options, callback } of resolveHandlers) {
+        if (options.namespace !== undefined) continue
+        if (!options.filter.test(source)) continue
+
+        const result = await callback({
+          path: source,
+          importer: importer ?? "",
+          namespace: "file",
+          resolveDir: importer ? NPath.dirname(importer) : process.cwd(),
+          kind: extraOptions.kind,
+        })
+        if (result?.path === undefined) continue
+
+        return { id: result.path, external: result.external }
+      }
+      return null
+    },
+    async load(id) {
+      for (const { options, callback } of loadHandlers) {
+        if (options.namespace !== undefined) continue
+        if (!options.filter.test(id)) continue
+
+        const result = await tracker.wrapLoad(() =>
+          Promise.resolve(
+            callback({
+              path: id,
+              namespace: "file",
+              defer: tracker.defer,
+            }),
+          )
+        )
+        if (result === undefined) continue
+
+        const contents = typeof result.contents === "string"
+          ? result.contents
+          : new TextDecoder().decode(result.contents)
+
+        // Rolldown dropped native CSS bundling (see
+        // https://github.com/rolldown/rolldown/issues/4271), so a "css"
+        // result can't be returned as a module's code. Emit it as an asset
+        // instead and let the importing module resolve to an empty stub.
+        if (result.loader === "css") {
+          this.emitFile({
+            type: "asset",
+            name: NPath.basename(id),
+            originalFileName: id,
+            source: contents,
+          })
+          return { code: "", moduleType: "empty" }
+        }
+
+        return {
+          code: contents,
+          moduleType: result.loader,
+        }
+      }
+      return null
+    },
+  }
+}

--- a/src/rolldown/index.ts
+++ b/src/rolldown/index.ts
@@ -1,1 +1,2 @@
 export * as RolldownBundle from "./RolldownBundle.ts"
+export * as RolldownPlugin from "./RolldownPlugin.ts"

--- a/src/tailwind/TailwindPlugin.ts
+++ b/src/tailwind/TailwindPlugin.ts
@@ -1,9 +1,15 @@
-import type { BunPlugin } from "bun"
 import * as NPath from "node:path"
+import type * as Plugin from "../bundler/Plugin.ts"
 import * as IgnoreFile from "../internal/IgnoreFile.ts"
 import * as NodeUtils from "../node/NodeUtils.ts"
 import { compile } from "./compile.ts"
 
+/**
+ * Builds a Tailwind CSS plugin against the bundler-agnostic {@link Plugin.Plugin}
+ * shape. Convert it for a specific bundler with the matching adapter:
+ * `bun/BunPlugin.toBunPlugin`, `esbuild/EsbuildPlugin.toEsbuildPlugin`, or
+ * `rolldown/RolldownPlugin.toRolldownPlugin`.
+ */
 export const make = (opts?: {
   /**
    * Pattern to match component and HTML files for class name extraction.
@@ -14,18 +20,14 @@ export const make = (opts?: {
    * Pattern to match CSS files that import Tailwind.
    */
   cssPattern?: RegExp
-
-  target?: "browser" | "bun" | "node"
-}): BunPlugin => {
+}): Plugin.Plugin => {
   const {
     filesPattern = /\.(jsx?|tsx?|html|svelte|vue|astro)$/,
     cssPattern = /\.css$/,
-    target = "browser",
   } = opts ?? {}
 
   return {
     name: "Tailwind.css plugin",
-    target,
     async setup(builder) {
       // (file) -> (class names)
       const classNameCandidates = new Map<string, Set<string>>()

--- a/src/tailwind/index.ts
+++ b/src/tailwind/index.ts
@@ -1,5 +1,6 @@
+import * as BunPlugin from "../bun/BunPlugin.ts"
 import * as TailwindPlugin from "./TailwindPlugin.ts"
 
 export * as TailwindPlugin from "./TailwindPlugin.ts"
 
-export default TailwindPlugin.make()
+export default BunPlugin.toBunPlugin(TailwindPlugin.make(), { target: "browser" })

--- a/src/tailwind/plugin.ts
+++ b/src/tailwind/plugin.ts
@@ -1,4 +1,5 @@
+import * as BunPlugin from "../bun/BunPlugin.ts"
 import * as TailwindPlugin from "./TailwindPlugin.ts"
 
 // Export as default to be used in bunfig.toml
-export default TailwindPlugin.make()
+export default BunPlugin.toBunPlugin(TailwindPlugin.make(), { target: "browser" })

--- a/test/bun/BunPlugin.test.ts
+++ b/test/bun/BunPlugin.test.ts
@@ -1,0 +1,58 @@
+import * as test from "bun:test"
+import * as Effect from "effect/Effect"
+import * as NPath from "node:path"
+import * as BunPlugin from "../../src/bun/BunPlugin.ts"
+import * as FileSystem from "../../src/FileSystem.ts"
+import { NodeFileSystem } from "../../src/node/index.ts"
+import * as TailwindPlugin from "../../src/tailwind/TailwindPlugin.ts"
+
+const makeFixture = () =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const tmpDir = yield* fs.makeTempDirectoryScoped({
+      prefix: "effect-start-bun-plugin-",
+      // Nested under the project's own directory so tailwindcss's module
+      // resolution walks up to the repo's node_modules.
+      directory: process.cwd(),
+    })
+    yield* fs.writeFileString(
+      NPath.join(tmpDir, "component.tsx"),
+      `export const Component = () => <div className="bg-red-500">Hi</div>`,
+    )
+    const cssPath = NPath.join(tmpDir, "app.css")
+    yield* fs.writeFileString(
+      cssPath,
+      `@import "tailwindcss";\n@source "./component.tsx";`,
+    )
+    return { tmpDir, cssPath }
+  })
+
+test.it("toBunPlugin adapts the generic Tailwind plugin for Bun.build", () =>
+  Effect
+    .gen(function*() {
+      const { cssPath } = yield* makeFixture()
+      const bunPlugin = BunPlugin.toBunPlugin(TailwindPlugin.make())
+
+      const output = yield* Effect.tryPromise(() =>
+        Bun.build({
+          entrypoints: [cssPath],
+          target: "browser",
+          plugins: [bunPlugin],
+        })
+      )
+
+      test
+        .expect(output.success)
+        .toBe(true)
+
+      const css = yield* Effect.promise(() => output.outputs[0]!.text())
+
+      test
+        .expect(css)
+        .toContain("bg-red-500")
+    })
+    .pipe(
+      Effect.scoped,
+      Effect.provide(NodeFileSystem.layer),
+      Effect.runPromise,
+    ))

--- a/test/bundler/DeferredLoad.test.ts
+++ b/test/bundler/DeferredLoad.test.ts
@@ -1,0 +1,88 @@
+import * as test from "bun:test"
+import * as DeferredLoad from "../../src/bundler/internal/DeferredLoad.ts"
+
+test.it("defer() resolves immediately when no other load is in flight", async () => {
+  const tracker = DeferredLoad.makeDeferredLoadTracker()
+
+  const order: Array<string> = []
+  await tracker.wrapLoad(async () => {
+    order.push("start")
+    await tracker.defer()
+    order.push("resumed")
+  })
+
+  test
+    .expect(order)
+    .toEqual(["start", "resumed"])
+})
+
+test.it("defer() waits for other in-flight loads to settle before resuming", async () => {
+  const tracker = DeferredLoad.makeDeferredLoadTracker()
+  const order: Array<string> = []
+
+  let releaseSibling: () => void
+  const siblingGate = new Promise<void>((resolve) => {
+    releaseSibling = resolve
+  })
+
+  const deferring = tracker.wrapLoad(async () => {
+    order.push("deferring:start")
+    // Yield once so the sibling load (started synchronously right after
+    // this call) has a chance to register as active before we defer.
+    await Promise.resolve()
+    await tracker.defer()
+    order.push("deferring:resumed")
+  })
+
+  const sibling = tracker.wrapLoad(async () => {
+    order.push("sibling:start")
+    await siblingGate
+    order.push("sibling:done")
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  test
+    .expect(order)
+    .toEqual(["deferring:start", "sibling:start"])
+
+  releaseSibling!()
+  await Promise.all([deferring, sibling])
+
+  test
+    .expect(order)
+    .toEqual(["deferring:start", "sibling:start", "sibling:done", "deferring:resumed"])
+})
+
+test.it("multiple deferred loads resume together once the last in-flight load settles", async () => {
+  const tracker = DeferredLoad.makeDeferredLoadTracker()
+  const resumed: Array<string> = []
+
+  let releaseBlocker: () => void
+  const blockerGate = new Promise<void>((resolve) => {
+    releaseBlocker = resolve
+  })
+
+  const blocker = tracker.wrapLoad(() => blockerGate.then(() => {}))
+  const a = tracker.wrapLoad(async () => {
+    await Promise.resolve()
+    await tracker.defer()
+    resumed.push("a")
+  })
+  const b = tracker.wrapLoad(async () => {
+    await Promise.resolve()
+    await tracker.defer()
+    resumed.push("b")
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  test
+    .expect(resumed)
+    .toEqual([])
+
+  releaseBlocker!()
+  await Promise.all([blocker, a, b])
+
+  test
+    .expect(resumed.sort())
+    .toEqual(["a", "b"])
+})

--- a/test/esbuild/EsbuildPlugin.test.ts
+++ b/test/esbuild/EsbuildPlugin.test.ts
@@ -1,0 +1,58 @@
+import * as test from "bun:test"
+import * as Effect from "effect/Effect"
+import * as esbuild from "esbuild"
+import * as NPath from "node:path"
+import * as EsbuildPlugin from "../../src/esbuild/EsbuildPlugin.ts"
+import * as FileSystem from "../../src/FileSystem.ts"
+import { NodeFileSystem } from "../../src/node/index.ts"
+import * as TailwindPlugin from "../../src/tailwind/TailwindPlugin.ts"
+
+const makeFixture = () =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const tmpDir = yield* fs.makeTempDirectoryScoped({
+      prefix: "effect-start-esbuild-plugin-",
+      directory: process.cwd(),
+    })
+    yield* fs.writeFileString(
+      NPath.join(tmpDir, "component.tsx"),
+      `export const Component = () => <div className="bg-red-500">Hi</div>`,
+    )
+    const cssPath = NPath.join(tmpDir, "app.css")
+    yield* fs.writeFileString(
+      cssPath,
+      `@import "tailwindcss";\n@source "./component.tsx";`,
+    )
+    return { tmpDir, cssPath }
+  })
+
+test.it("toEsbuildPlugin adapts the generic Tailwind plugin for esbuild.build", () =>
+  Effect
+    .gen(function*() {
+      const { cssPath } = yield* makeFixture()
+      const plugin = EsbuildPlugin.toEsbuildPlugin(TailwindPlugin.make())
+
+      const output = yield* Effect.tryPromise(() =>
+        esbuild.build({
+          entryPoints: [cssPath],
+          bundle: true,
+          write: false,
+          plugins: [plugin],
+        })
+      )
+
+      test
+        .expect(output.outputFiles.length)
+        .toBeGreaterThan(0)
+
+      const css = output.outputFiles[0]!.text
+
+      test
+        .expect(css)
+        .toContain("bg-red-500")
+    })
+    .pipe(
+      Effect.scoped,
+      Effect.provide(NodeFileSystem.layer),
+      Effect.runPromise,
+    ))

--- a/test/rolldown/RolldownPlugin.test.ts
+++ b/test/rolldown/RolldownPlugin.test.ts
@@ -1,0 +1,59 @@
+import * as test from "bun:test"
+import * as Effect from "effect/Effect"
+import * as NPath from "node:path"
+import * as rolldown from "rolldown"
+import * as FileSystem from "../../src/FileSystem.ts"
+import { NodeFileSystem } from "../../src/node/index.ts"
+import * as RolldownPlugin from "../../src/rolldown/RolldownPlugin.ts"
+import * as TailwindPlugin from "../../src/tailwind/TailwindPlugin.ts"
+
+const makeFixture = () =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const tmpDir = yield* fs.makeTempDirectoryScoped({
+      prefix: "effect-start-rolldown-plugin-",
+      directory: process.cwd(),
+    })
+    yield* fs.writeFileString(
+      NPath.join(tmpDir, "component.tsx"),
+      `export const Component = () => <div className="bg-red-500">Hi</div>`,
+    )
+    const cssPath = NPath.join(tmpDir, "app.css")
+    yield* fs.writeFileString(
+      cssPath,
+      `@import "tailwindcss";\n@source "./component.tsx";`,
+    )
+    return { tmpDir, cssPath }
+  })
+
+test.it("toRolldownPlugin adapts the generic Tailwind plugin for rolldown.build", () =>
+  Effect
+    .gen(function*() {
+      const { cssPath } = yield* makeFixture()
+      const plugin = RolldownPlugin.toRolldownPlugin(TailwindPlugin.make())
+
+      const output = yield* Effect.tryPromise(() =>
+        rolldown.build({
+          input: cssPath,
+          plugins: [plugin],
+          write: false,
+        })
+      )
+
+      const cssAsset = output.output.find((item) => item.fileName.endsWith(".css"))
+
+      test
+        .expect(cssAsset)
+        .toBeDefined()
+
+      const source = cssAsset!.type === "asset" ? cssAsset!.source : ""
+
+      test
+        .expect(String(source))
+        .toContain("bg-red-500")
+    })
+    .pipe(
+      Effect.scoped,
+      Effect.provide(NodeFileSystem.layer),
+      Effect.runPromise,
+    ))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #49

## Summary

Bundler-specific plugins (e.g. Bun Tailwind) are generalized to an esbuild-shaped plugin API shared across Bun, esbuild, and Rolldown — without taking an `unplugin` dependency.

## Changes

- `bundler/Plugin` with `onResolve` / `onLoad` (+ Bun-style `defer`)
- Adapters: `BunPlugin`, `EsbuildPlugin`, `RolldownPlugin`
- Refactor Tailwind to return the generic Plugin

## Test plan

- [x] `bun test test/bun/BunPlugin.test.ts test/esbuild/EsbuildPlugin.test.ts test/rolldown/RolldownPlugin.test.ts test/bundler/DeferredLoad.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

