### PR TITLE
Store route manifest in-memory / virtual module (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ It exports a layer that applies configuration and changes the behavior of the se
 import { FileRouter, Start } from "effect-start"
 
 export default Start.layer(
-  FileRouter.layer({
-    load: () => import("./routes/routes.gen.ts"),
-    path: import.meta.resolve("./routes/routes.gen.ts"),
-  }),
+  FileRouter.layer(),
 )
 
 if (import.meta.main) {
@@ -43,9 +40,28 @@ src/routes
 │   ├── layer.tsx
 │   └── route.tsx
 ├── layer.tsx
-├── routes.gen.ts
 └── route.tsx
 ```
+
+`FileRouter.layer()` scans `src/routes` and builds the route map in memory —
+no generated manifest file is ever written next to your routes, so there's
+nothing there for an agent (or you) to accidentally edit.
+
+If you need typed `DevRoutes` support, pass `load`/`path` to have
+`FileRouter.layer()` maintain a `.server.ts` manifest instead:
+
+```typescript
+FileRouter.layer({
+  load: () => import("./routes/.server.ts"),
+  path: import.meta.resolve("./routes/.server.ts"),
+})
+```
+
+This does write a real file, so treat it like a build artifact (e.g. add it
+to `.gitignore`). When bundling into a single deployable artifact, prefer
+serving the manifest as a virtual module via a bundler plugin — see
+`BunFileRouterPlugin` in `effect-start/bun` — so no manifest file exists on
+disk even for bundled builds.
 
 ### Tailwind CSS Support
 

--- a/src/FileRouter.ts
+++ b/src/FileRouter.ts
@@ -188,11 +188,28 @@ function layerGenerated(
   )
 }
 
+/**
+ * Scans `routesPath` (default: `<entrypoint>/routes`) and builds the route
+ * map in memory, with no manifest file ever written to disk. This is the
+ * recommended default for bun/node: agents and editors can't accidentally
+ * "fix" a file that doesn't exist.
+ */
 export function layer(): Layer.Layer<
   Route.Routes,
   FileRouterError,
   FileSystem.FileSystem
 >
+/**
+ * Loads a pre-built {@link FileRouteMap}, e.g. for typed `DevRoutes` support.
+ * `load` is re-imported and `path`'s directory is re-scanned to keep the
+ * `.server.ts` manifest current as files change; the manifest itself is
+ * still a real file on disk, so prefer {@link layer}`()` unless you need it.
+ *
+ * When targeting a single bundled artifact (edge/serverless deploys),
+ * pair this with a bundler plugin that serves the manifest as a virtual
+ * module instead of a file, e.g. `BunFileRouterPlugin` from
+ * `effect-start/bun`.
+ */
 export function layer<const T extends FileRouteMap>(
   load: () => Promise<{ default: T }>,
 ): Layer.Layer<

--- a/src/bun/BunFileRouterPlugin.ts
+++ b/src/bun/BunFileRouterPlugin.ts
@@ -1,0 +1,76 @@
+import type { BunPlugin, Loader } from "bun"
+import * as Effect from "effect/Effect"
+import * as NPath from "node:path"
+import * as FileRouter from "../FileRouter.ts"
+import * as FileRouterCodegen from "../FileRouterCodegen.ts"
+import * as NodeFileSystem from "../node/NodeFileSystem.ts"
+
+/**
+ * Default specifier apps import to get the file router manifest at build
+ * time. Prefixed with `virtual:` so it's obviously not a real file on disk.
+ */
+export const DEFAULT_MODULE_ID = "virtual:effect-start/file-routes"
+
+const NAMESPACE = "effect-start-file-routes"
+
+export type Options = {
+  /** Directory to scan for `route.tsx`/`layer.tsx` files. */
+  path: string
+  /** Specifier apps use to import the generated manifest. */
+  moduleId?: string
+}
+
+/**
+ * Bun plugin that generates the file-router manifest as a virtual module
+ * instead of writing a `.server.ts`/`routes.gen.ts` file to disk.
+ *
+ * Register it both for local development (`Bun.plugin`) and for production
+ * builds (`Bun.build({ plugins: [...] })`) so `import(moduleId)` always
+ * resolves, without ever creating a file agents could mistake for source
+ * code and edit.
+ *
+ * ```ts
+ * FileRouter.layer({
+ *   load: () => import(BunFileRouterPlugin.DEFAULT_MODULE_ID),
+ *   path: routesDir,
+ * })
+ * ```
+ */
+export function make(options: Options): BunPlugin {
+  const routesPath = NPath.resolve(options.path)
+  const moduleId = options.moduleId ?? DEFAULT_MODULE_ID
+  // Never actually written; only used so relative imports emitted by
+  // `FileRouterCodegen.generateCode` resolve against `routesPath`.
+  const virtualFilePath = NPath.join(routesPath, "__file-routes.virtual.ts")
+  const resolveFilter = new RegExp(`^${escapeRegExp(moduleId)}$`)
+
+  return {
+    name: "effect-start-file-router",
+    setup(build) {
+      build.onResolve({ filter: resolveFilter }, () => ({
+        path: virtualFilePath,
+        namespace: NAMESPACE,
+      }))
+
+      build.onLoad(
+        { filter: /.*/, namespace: NAMESPACE },
+        async (): Promise<{ contents: string; loader: Loader }> => {
+          const fileRoutes = await Effect.runPromise(
+            FileRouter.walkRoutesDirectory(routesPath).pipe(
+              Effect.provide(NodeFileSystem.layer),
+            ),
+          )
+
+          return {
+            contents: FileRouterCodegen.generateCode(fileRoutes) ?? "export default {}\n",
+            loader: "ts",
+          }
+        },
+      )
+    },
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -1,5 +1,6 @@
 export * as BunBundle from "./BunBundle.ts"
 export * as BunChildProcessSpawner from "./BunChildProcessSpawner.ts"
+export * as BunFileRouterPlugin from "./BunFileRouterPlugin.ts"
 export * as BunImportTrackerPlugin from "./BunImportTrackerPlugin.ts"
 export * as BunRoute from "./BunRoute.ts"
 export * as BunServer from "./BunServer.ts"

--- a/test/bun/BunFileRouterPlugin.test.ts
+++ b/test/bun/BunFileRouterPlugin.test.ts
@@ -1,0 +1,114 @@
+import * as test from "bun:test"
+import * as NFs from "node:fs"
+import * as NOs from "node:os"
+import * as NPath from "node:path"
+import * as BunFileRouterPlugin from "../../src/bun/BunFileRouterPlugin.ts"
+
+const writeTree = (root: string, files: Record<string, string>) => {
+  for (const [path, content] of Object.entries(files)) {
+    const full = NPath.join(root, path)
+    NFs.mkdirSync(NPath.dirname(full), { recursive: true })
+    NFs.writeFileSync(full, content)
+  }
+}
+
+const makeRoutesDir = (files: Record<string, string>) => {
+  const root = NFs.mkdtempSync(NPath.join(NOs.tmpdir(), "effect-start-plugin-"))
+  writeTree(root, files)
+  return root
+}
+
+test.it("bundles the manifest as a virtual module without touching disk", async () => {
+  const routesDir = makeRoutesDir({
+    "route.tsx": `export default "ROOT_MARKER"\n`,
+    "about/route.tsx": `export default "ABOUT_MARKER"\n`,
+  })
+  const entryDir = NFs.mkdtempSync(NPath.join(NOs.tmpdir(), "effect-start-entry-"))
+  const entryPath = NPath.join(entryDir, "entry.ts")
+  NFs.writeFileSync(
+    entryPath,
+    `export { default } from ${JSON.stringify(BunFileRouterPlugin.DEFAULT_MODULE_ID)}\n`,
+  )
+
+  try {
+    const filesBefore = NFs.readdirSync(routesDir, { recursive: true })
+
+    const output = await Bun.build({
+      entrypoints: [entryPath],
+      target: "bun",
+      plugins: [BunFileRouterPlugin.make({ path: routesDir })],
+    })
+
+    test.expect(output.success).toBe(true)
+
+    const bundled = (
+      await Promise.all(output.outputs.map((o) => o.text()))
+    )
+      .join("\n")
+
+    // route contents were inlined, not left as a runtime directory scan
+    test.expect(bundled).toContain("ROOT_MARKER")
+    test.expect(bundled).toContain("ABOUT_MARKER")
+    test.expect(bundled).not.toContain("readdirSync")
+
+    // never wrote a manifest file next to the routes
+    test.expect(NFs.readdirSync(routesDir, { recursive: true })).toEqual(filesBefore)
+  } finally {
+    NFs.rmSync(routesDir, { recursive: true, force: true })
+    NFs.rmSync(entryDir, { recursive: true, force: true })
+  }
+})
+
+test.it("supports a custom module id", async () => {
+  const routesDir = makeRoutesDir({
+    "route.tsx": `export default "ROOT_MARKER"\n`,
+  })
+  const entryDir = NFs.mkdtempSync(NPath.join(NOs.tmpdir(), "effect-start-entry-"))
+  const entryPath = NPath.join(entryDir, "entry.ts")
+  const moduleId = "virtual:my-app/routes"
+  NFs.writeFileSync(
+    entryPath,
+    `export { default } from ${JSON.stringify(moduleId)}\n`,
+  )
+
+  try {
+    const output = await Bun.build({
+      entrypoints: [entryPath],
+      target: "bun",
+      plugins: [BunFileRouterPlugin.make({ path: routesDir, moduleId })],
+    })
+
+    test.expect(output.success).toBe(true)
+    const bundled = (
+      await Promise.all(output.outputs.map((o) => o.text()))
+    )
+      .join("\n")
+    test.expect(bundled).toContain("ROOT_MARKER")
+  } finally {
+    NFs.rmSync(routesDir, { recursive: true, force: true })
+    NFs.rmSync(entryDir, { recursive: true, force: true })
+  }
+})
+
+test.it("fails to resolve the manifest specifier when the plugin isn't registered", async () => {
+  const entryDir = NFs.mkdtempSync(NPath.join(NOs.tmpdir(), "effect-start-entry-"))
+  const entryPath = NPath.join(entryDir, "entry.ts")
+  NFs.writeFileSync(
+    entryPath,
+    `export { default } from ${JSON.stringify(BunFileRouterPlugin.DEFAULT_MODULE_ID)}\n`,
+  )
+
+  try {
+    await test
+      .expect(
+        Bun.build({
+          entrypoints: [entryPath],
+          target: "bun",
+        }),
+      )
+      .rejects
+      .toBeDefined()
+  } finally {
+    NFs.rmSync(entryDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #91

## Summary

Agents keep editing generated route manifest files. In-memory scanning already worked for `FileRouter.layer()` without `load`; this makes that the documented default and adds a Bun virtual-module plugin for bundled deploys so no on-disk manifest is required.

## Changes

- New `BunFileRouterPlugin` serving `virtual:effect-start/file-routes` during `Bun.build`
- Clarify `FileRouter.layer` docs: in-memory default; `load`/`path` opt-in for typed DevRoutes
- Update README to lead with in-memory layer

## Test plan

- [x] `bun test test/bun/BunFileRouterPlugin.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

