### PR TITLE
Runtime-agnostic Server interface with hostname/port (#90)

### DIFF
--- a/src/StartServer.ts
+++ b/src/StartServer.ts
@@ -1,19 +1,22 @@
 /**
  * The platform-agnostic server surface a route handler needs at request time —
- * upgrading a connection to a {@link Socket.Socket} and forking work into the
- * server's scope. A concrete server (e.g. `bun/BunServer`) implements it and
+ * upgrading a connection to a {@link Socket.Socket}, forking work into the
+ * server's scope, and reading the address it's reachable at. A concrete server
+ * (e.g. `bun/BunServer`, `cloudflare/CloudflareServer`) implements it and
  * provides this tag alongside its own.
  *
  * Keeping this interface free of any platform import (no `bun`, no `node:*`)
  * lets browser-targeted modules depend on `Route.ws` without pulling a server
- * runtime — and its `import "bun"` — into the bundle.
+ * runtime — and its `import "bun"` — into the bundle. It's also why
+ * serverless runtimes (no real listening socket) can implement it too: their
+ * `address` is synthetic rather than resolved from a bind.
  */
 import * as Context from "effect/Context"
-import type * as Effect from "effect/Effect"
+import * as Effect from "effect/Effect"
 import type * as Scope from "effect/Scope"
-import type * as SocketAddress from "./internal/SocketAddress.ts"
+import * as SocketAddress from "./internal/SocketAddress.ts"
 import type * as Route from "./Route.ts"
-import type * as Socket from "./Socket.ts"
+import * as Socket from "./Socket.ts"
 
 export type Address = SocketAddress.Address
 
@@ -22,6 +25,8 @@ export interface StartServer {
   // route handler's requirements rather than surfaced to the app.
   readonly [Route.IntrinsicService]?: never
   readonly address: Address
+  readonly hostname: string
+  readonly port: number
   readonly url: string
   readonly upgrade: (
     request: Request,
@@ -38,3 +43,46 @@ export interface StartServer {
 }
 
 export const StartServer = Context.GenericTag<StartServer>("effect-start/StartServer")
+
+/**
+ * Forks socket handlers into `scope` rather than the caller's, so they are
+ * interrupted (and their finalizers run) when that scope closes instead of
+ * outliving it. Shared by every {@link StartServer} implementation that has
+ * an actual lifetime to fork into (a bound socket, a request scope, ...).
+ */
+export const runForkIn =
+  (scope: Scope.Scope) => <R>(effect: Effect.Effect<void, never, R>): Effect.Effect<void, never, R> =>
+    Effect.asVoid(Effect.forkIn(effect, scope))
+
+const unsupportedUpgrade: StartServer["upgrade"] = () =>
+  Effect.fail(
+    new Socket.SocketError({
+      reason: new Socket.SocketOpenError({
+        kind: "Unknown",
+        cause: new Error("this server does not support upgrading connections to a socket"),
+      }),
+    }),
+  )
+
+/**
+ * Builds a minimal {@link StartServer} from just an {@link Address}, with a
+ * `runFork` that forks into the current scope and an `upgrade` that fails
+ * with a `SocketOpenError` (surfaced by `Route.ws` as a 426 response) unless
+ * overridden. Useful for runtimes with no persistent listening socket — e.g.
+ * a serverless handler that only knows its address once invoked.
+ */
+export const make = (options: {
+  readonly address: Address
+  readonly upgrade?: StartServer["upgrade"]
+}): Effect.Effect<StartServer, never, Scope.Scope> =>
+  Effect.gen(function*() {
+    const scope = yield* Effect.scope
+    return StartServer.of({
+      address: options.address,
+      hostname: SocketAddress.hostname(options.address),
+      port: SocketAddress.port(options.address),
+      url: SocketAddress.urlOf(options.address),
+      upgrade: options.upgrade ?? unsupportedUpgrade,
+      runFork: runForkIn(scope),
+    })
+  })

--- a/src/bun/BunServer.ts
+++ b/src/bun/BunServer.ts
@@ -94,9 +94,7 @@ export const make = (
     // (and any acquired resources) are released instead of leaking. forkIn
     // preserves the caller's requirements, so the handler keeps the app's R.
     const handlerScope = yield* Effect.scope
-    const runFork = <R>(
-      effect: Effect.Effect<void, never, R>,
-    ): Effect.Effect<void, never, R> => Effect.asVoid(Effect.forkIn(effect, handlerScope))
+    const runFork = StartServer.runForkIn(handlerScope)
 
     let boundServer: Bun.Server<WebSocketContext>
     let boundAddress: SocketAddress.Address
@@ -110,13 +108,14 @@ export const make = (
         get address() {
           return boundAddress
         },
+        get hostname() {
+          return SocketAddress.hostname(boundAddress)
+        },
+        get port() {
+          return SocketAddress.port(boundAddress)
+        },
         get url() {
-          if (boundAddress._tag === "UnixAddress") return "http://localhost"
-
-          const hostname = boundAddress.hostname === "0.0.0.0" || boundAddress.hostname === "::"
-            ? "localhost"
-            : boundAddress.hostname
-          return `http://${hostname}:${boundAddress.port}`
+          return SocketAddress.urlOf(boundAddress, "http")
         },
         pushHandler(fetch) {
           handlerStack

--- a/src/cloudflare/CloudflareServer.ts
+++ b/src/cloudflare/CloudflareServer.ts
@@ -1,0 +1,52 @@
+/**
+ * A minimal {@link StartServer.StartServer} for edge/serverless runtimes with
+ * no persistent listening socket — Cloudflare Workers, and any other
+ * fetch-per-invocation platform. There's nothing to bind, so `address` is a
+ * synthetic {@link SocketAddress.WorkerAddress} rather than one resolved from
+ * a real listen call.
+ *
+ * `upgrade` fails with a `SocketOpenError` (surfaced by `Route.ws` as a 426
+ * response) until a platform-specific fetch adapter — wiring `WebSocketPair`
+ * and the platform's `Response.webSocket` protocol — provides its own.
+ */
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import type * as Scope from "effect/Scope"
+import * as SocketAddress from "../internal/SocketAddress.ts"
+import * as StartServer from "../StartServer.ts"
+
+export interface CloudflareServer extends StartServer.StartServer {}
+
+export const CloudflareServer = Context.GenericTag<CloudflareServer>(
+  "effect-start/CloudflareServer",
+)
+
+export interface CloudflareServerOptions {
+  /**
+   * Public hostname the Worker is reachable at — a custom domain or
+   * `<name>.<subdomain>.workers.dev`. Purely informational: Workers don't
+   * bind to it, the platform's edge does. Defaults to `"workers.dev"`.
+   */
+  readonly hostname?: string | undefined
+  /** Defaults to `443` — Workers are only ever reachable over HTTPS. */
+  readonly port?: number | undefined
+}
+
+export const make = (
+  options?: CloudflareServerOptions,
+): Effect.Effect<CloudflareServer, never, Scope.Scope> =>
+  StartServer.make({
+    address: SocketAddress.worker(options?.hostname, options?.port),
+  })
+
+export const layer = (
+  options?: CloudflareServerOptions,
+): Layer.Layer<CloudflareServer | StartServer.StartServer> =>
+  Layer.scopedContext(
+    Effect.map(make(options), (server) =>
+      Context.empty().pipe(
+        Context.add(CloudflareServer, server),
+        Context.add(StartServer.StartServer, server),
+      )),
+  )

--- a/src/cloudflare/index.ts
+++ b/src/cloudflare/index.ts
@@ -1,1 +1,2 @@
+export * as CloudflareServer from "./CloudflareServer.ts"
 export * as CloudflareTunnel from "./CloudflareTunnel.ts"

--- a/src/internal/SocketAddress.ts
+++ b/src/internal/SocketAddress.ts
@@ -7,7 +7,11 @@
  * read the resolved address from the server rather than the options.
  */
 
-export type Address = TcpAddress | UnixAddress
+// WorkerAddress covers serverless runtimes (e.g. Cloudflare Workers) that
+// never bind a real socket: the platform's edge routes requests to the
+// isolate before a handler runs, so hostname/port are synthetic rather than
+// something the server itself resolved.
+export type Address = TcpAddress | UnixAddress | WorkerAddress
 
 export interface TcpAddress {
   readonly _tag: "TcpAddress"
@@ -20,6 +24,12 @@ export interface UnixAddress {
   readonly path: string
 }
 
+export interface WorkerAddress {
+  readonly _tag: "WorkerAddress"
+  readonly hostname: string
+  readonly port: number
+}
+
 export const tcp = (hostname: string, port: number): TcpAddress => ({
   _tag: "TcpAddress",
   hostname,
@@ -30,3 +40,26 @@ export const unix = (path: string): UnixAddress => ({
   _tag: "UnixAddress",
   path,
 })
+
+export const worker = (hostname = "workers.dev", port = 443): WorkerAddress => ({
+  _tag: "WorkerAddress",
+  hostname,
+  port,
+})
+
+// UnixAddress has no hostname/port of its own, so callers that need a single
+// identity across every Address variant get a local-loopback fallback.
+export const hostname = (address: Address): string => address._tag === "UnixAddress" ? "localhost" : address.hostname
+
+export const port = (address: Address): number => address._tag === "UnixAddress" ? 0 : address.port
+
+export const defaultScheme = (address: Address): string => address._tag === "WorkerAddress" ? "https" : "http"
+
+// A wildcard bind isn't reachable at that literal hostname from a browser, so
+// rewrite it to localhost for display purposes only (the resolved address
+// itself is left untouched).
+export const urlOf = (address: Address, scheme: string = defaultScheme(address)): string => {
+  if (address._tag === "UnixAddress") return `${scheme}://localhost`
+  const host = address.hostname === "0.0.0.0" || address.hostname === "::" ? "localhost" : address.hostname
+  return `${scheme}://${host}:${address.port}`
+}

--- a/test/StartServer.test.ts
+++ b/test/StartServer.test.ts
@@ -1,0 +1,130 @@
+import * as test from "bun:test"
+import * as Socket from "effect-start/Socket"
+import * as StartServer from "effect-start/StartServer"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Scope from "effect/Scope"
+import * as SocketAddress from "../src/internal/SocketAddress.ts"
+
+test.describe("make", () => {
+  test.test("exposes hostname/port/url derived from the given address", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* StartServer.make({
+          address: SocketAddress.tcp("example.com", 4000),
+        })
+
+        test
+          .expect(server.address)
+          .toEqual({ _tag: "TcpAddress", hostname: "example.com", port: 4000 })
+        test
+          .expect(server.hostname)
+          .toBe("example.com")
+        test
+          .expect(server.port)
+          .toBe(4000)
+        test
+          .expect(server.url)
+          .toBe("http://example.com:4000")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("derives a synthetic hostname/port for a WorkerAddress", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* StartServer.make({
+          address: SocketAddress.worker("my-app.workers.dev", 443),
+        })
+
+        test
+          .expect(server.hostname)
+          .toBe("my-app.workers.dev")
+        test
+          .expect(server.port)
+          .toBe(443)
+        test
+          .expect(server.url)
+          .toBe("https://my-app.workers.dev:443")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("upgrade fails with a SocketOpenError by default", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* StartServer.make({
+          address: SocketAddress.worker(),
+        })
+        const scope = yield* Effect.scope
+        const error = yield* Effect.flip(
+          server.upgrade(new Request("http://localhost/"), scope),
+        )
+
+        test
+          .expect(error.reason._tag)
+          .toBe("SocketOpenError")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("upgrade can be overridden", () => {
+    const socket = Socket.make({
+      runRaw: () => Effect.void,
+      writer: Effect.succeed(() => Effect.void),
+    })
+
+    return Effect
+      .gen(function*() {
+        const server = yield* StartServer.make({
+          address: SocketAddress.worker(),
+          upgrade: () => Effect.succeed(socket),
+        })
+        const scope = yield* Effect.scope
+        const result = yield* server.upgrade(new Request("http://localhost/"), scope)
+
+        test
+          .expect(result)
+          .toBe(socket)
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      )
+  })
+
+  test.test("runFork forks into the server's scope and is interrupted when it closes", () =>
+    Effect
+      .gen(function*() {
+        const scope = yield* Scope.make()
+        const server = yield* Scope.extend(
+          StartServer.make({ address: SocketAddress.worker() }),
+          scope,
+        )
+
+        const interrupted = yield* Deferred.make<void>()
+        yield* server.runFork(
+          Effect.onInterrupt(Effect.never, () => Deferred.succeed(interrupted, void 0)),
+        )
+        // Give the forked fiber a scheduling tick to start running (and
+        // install its interrupt handler) before the scope closes under it.
+        yield* Effect.sleep("10 millis")
+
+        yield* Scope.close(scope, Exit.void)
+
+        yield* Deferred.await(interrupted).pipe(
+          Effect.timeoutFail({
+            duration: "1 second",
+            onTimeout: () => new Error("expected runFork's effect to be interrupted"),
+          }),
+        )
+      })
+      .pipe(Effect.runPromise))
+})

--- a/test/bun/BunServer.test.ts
+++ b/test/bun/BunServer.test.ts
@@ -4,6 +4,7 @@ import * as FileSystem from "effect-start/FileSystem"
 import { NodeFileSystem } from "effect-start/node"
 import * as Route from "effect-start/Route"
 import * as Start from "effect-start/Start"
+import * as StartServer from "effect-start/StartServer"
 import * as ConfigProvider from "effect/ConfigProvider"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
@@ -86,7 +87,78 @@ test.test("uses localhost URL for wildcard binds", () =>
         .expect(ipv6Server.url)
         .toBe(`http://localhost:${ipv6Server.server.port}`)
     })
-    .pipe(Effect.scoped, Effect.runPromise))
+    .pipe(
+      Effect.scoped,
+      Effect.runPromise,
+    ))
+
+test.describe("Server interface (StartServer)", () => {
+  test.test("hostname/port mirror the underlying Bun server, address is a TcpAddress", () =>
+    Effect
+      .gen(function*() {
+        const bunServer = yield* BunServer.make({ hostname: "127.0.0.1", port: 0 })
+
+        test
+          .expect(bunServer.hostname)
+          .toBe(bunServer.server.hostname!)
+        test
+          .expect(bunServer.port)
+          .toBe(bunServer.server.port!)
+        test
+          .expect(bunServer.address)
+          .toEqual({
+            _tag: "TcpAddress",
+            hostname: bunServer.server.hostname!,
+            port: bunServer.server.port!,
+          })
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("hostname/port fall back to localhost/0 for a unix socket address", () => {
+    const unixPath = NPath.join(NOs.tmpdir(), `effect-start-test-${Date.now()}.sock`)
+
+    return Effect
+      .gen(function*() {
+        const bunServer = yield* BunServer.make({ unix: unixPath })
+
+        test
+          .expect(bunServer.address)
+          .toEqual({ _tag: "UnixAddress", path: unixPath })
+        test
+          .expect(bunServer.hostname)
+          .toBe("localhost")
+        test
+          .expect(bunServer.port)
+          .toBe(0)
+        test
+          .expect(bunServer.url)
+          .toBe("http://localhost")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      )
+  })
+
+  test.test("the same instance satisfies both BunServer and StartServer tags", () =>
+    Effect
+      .gen(function*() {
+        const bunServer = yield* BunServer.BunServer
+        const startServer = yield* StartServer.StartServer
+
+        test
+          .expect(startServer)
+          .toBe(bunServer)
+      })
+      .pipe(
+        Effect.provide(BunServer.layer({ port: 0 })),
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+})
 
 test.describe("smart port selection", () => {
   test.test.skipIf(process.stdout.isTTY)(

--- a/test/cloudflare/CloudflareServer.test.ts
+++ b/test/cloudflare/CloudflareServer.test.ts
@@ -1,0 +1,126 @@
+import * as test from "bun:test"
+import { CloudflareServer } from "effect-start/cloudflare"
+import * as Route from "effect-start/Route"
+import * as RouteHttp from "effect-start/RouteHttp"
+import * as StartServer from "effect-start/StartServer"
+import * as Effect from "effect/Effect"
+import * as Runtime from "effect/Runtime"
+
+test.describe("make", () => {
+  test.test("defaults to a synthetic workers.dev address on port 443", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* CloudflareServer.make()
+
+        test
+          .expect(server.address)
+          .toEqual({ _tag: "WorkerAddress", hostname: "workers.dev", port: 443 })
+        test
+          .expect(server.hostname)
+          .toBe("workers.dev")
+        test
+          .expect(server.port)
+          .toBe(443)
+        test
+          .expect(server.url)
+          .toBe("https://workers.dev:443")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("accepts a custom public hostname and port", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* CloudflareServer.make({
+          hostname: "my-app.example.com",
+          port: 8443,
+        })
+
+        test
+          .expect(server.hostname)
+          .toBe("my-app.example.com")
+        test
+          .expect(server.port)
+          .toBe(8443)
+        test
+          .expect(server.url)
+          .toBe("https://my-app.example.com:8443")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+
+  test.test("has no persistent socket to upgrade, so it fails with a SocketOpenError", () =>
+    Effect
+      .gen(function*() {
+        const server = yield* CloudflareServer.make()
+        const scope = yield* Effect.scope
+        const error = yield* Effect.flip(
+          server.upgrade(new Request("http://localhost/"), scope),
+        )
+
+        test
+          .expect(error.reason._tag)
+          .toBe("SocketOpenError")
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+})
+
+test.describe("layer", () => {
+  test.test("provides both CloudflareServer and StartServer backed by the same instance", () =>
+    Effect
+      .gen(function*() {
+        const cloudflareServer = yield* CloudflareServer.CloudflareServer
+        const startServer = yield* StartServer.StartServer
+
+        test
+          .expect(startServer)
+          .toBe(cloudflareServer)
+      })
+      .pipe(
+        Effect.provide(CloudflareServer.layer({ hostname: "my-app.workers.dev" })),
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+})
+
+test.describe("Route.ws integration", () => {
+  test.test("a fetch-style handler responds 426 instead of hanging, since there's no socket to upgrade", () =>
+    Effect
+      .gen(function*() {
+        const route = Route.get(Route.ws(function*(ctx) {
+          const write = yield* ctx.socket.writer
+          yield* ctx.socket.runRaw((data) => write(data))
+        }))
+
+        const server = yield* CloudflareServer.make()
+        const runtime = yield* Effect.runtime().pipe(
+          Effect.map(Runtime.provideService(StartServer.StartServer, server)),
+        )
+        const handler = RouteHttp.toWebHandlerRuntime(runtime)(route)
+
+        const response = yield* Effect.promise(() =>
+          Promise.resolve(
+            handler(
+              new Request("https://my-app.workers.dev/ws", {
+                headers: { upgrade: "websocket", connection: "Upgrade" },
+              }),
+            ),
+          )
+        )
+
+        test
+          .expect(response.status)
+          .toBe(426)
+      })
+      .pipe(
+        Effect.scoped,
+        Effect.runPromise,
+      ))
+})

--- a/test/internal/SocketAddress.test.ts
+++ b/test/internal/SocketAddress.test.ts
@@ -1,0 +1,95 @@
+import * as test from "bun:test"
+import * as SocketAddress from "../../src/internal/SocketAddress.ts"
+
+test.describe("hostname", () => {
+  test.test("returns the TcpAddress hostname", () => {
+    test
+      .expect(SocketAddress.hostname(SocketAddress.tcp("example.com", 8080)))
+      .toBe("example.com")
+  })
+
+  test.test("returns the WorkerAddress hostname", () => {
+    test
+      .expect(SocketAddress.hostname(SocketAddress.worker("my-worker.workers.dev", 443)))
+      .toBe("my-worker.workers.dev")
+  })
+
+  test.test("falls back to localhost for UnixAddress", () => {
+    test
+      .expect(SocketAddress.hostname(SocketAddress.unix("/tmp/app.sock")))
+      .toBe("localhost")
+  })
+})
+
+test.describe("port", () => {
+  test.test("returns the TcpAddress port", () => {
+    test
+      .expect(SocketAddress.port(SocketAddress.tcp("example.com", 8080)))
+      .toBe(8080)
+  })
+
+  test.test("returns the WorkerAddress port", () => {
+    test
+      .expect(SocketAddress.port(SocketAddress.worker("example.com", 8443)))
+      .toBe(8443)
+  })
+
+  test.test("falls back to 0 for UnixAddress", () => {
+    test
+      .expect(SocketAddress.port(SocketAddress.unix("/tmp/app.sock")))
+      .toBe(0)
+  })
+})
+
+test.describe("worker", () => {
+  test.test("defaults to workers.dev on port 443", () => {
+    const address = SocketAddress.worker()
+
+    test
+      .expect(address)
+      .toEqual({ _tag: "WorkerAddress", hostname: "workers.dev", port: 443 })
+  })
+
+  test.test("accepts a custom hostname and port", () => {
+    const address = SocketAddress.worker("my-app.example.com", 8443)
+
+    test
+      .expect(address)
+      .toEqual({ _tag: "WorkerAddress", hostname: "my-app.example.com", port: 8443 })
+  })
+})
+
+test.describe("urlOf", () => {
+  test.test("uses https by default for a WorkerAddress", () => {
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.worker("my-app.workers.dev", 443)))
+      .toBe("https://my-app.workers.dev:443")
+  })
+
+  test.test("uses http by default for a TcpAddress", () => {
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.tcp("example.com", 3000)))
+      .toBe("http://example.com:3000")
+  })
+
+  test.test("rewrites wildcard binds to localhost", () => {
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.tcp("0.0.0.0", 3000)))
+      .toBe("http://localhost:3000")
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.tcp("::", 3000)))
+      .toBe("http://localhost:3000")
+  })
+
+  test.test("drops the path for a UnixAddress", () => {
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.unix("/tmp/app.sock")))
+      .toBe("http://localhost")
+  })
+
+  test.test("accepts an explicit scheme override", () => {
+    test
+      .expect(SocketAddress.urlOf(SocketAddress.tcp("example.com", 443), "https"))
+      .toBe("https://example.com:443")
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #90

## Summary

Promotes a runtime-agnostic listen identity on `StartServer` (hostname/port) and adds a Cloudflare Workers-oriented serverless server backed by a synthetic address.

## Changes

- `StartServer.hostname` / `port` plus shared `make()` factory
- `WorkerAddress` in SocketAddress for serverless runtimes
- Wire BunServer to shared helpers
- New `CloudflareServer` with synthetic address and graceful upgrade failure

## Test plan

- [x] `bun test test/StartServer.test.ts test/cloudflare/CloudflareServer.test.ts test/internal/SocketAddress.test.ts test/bun/BunServer.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff368-6aaf-7711-b875-9bb580e1c215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff368-6aaf-7711-b875-9bb580e1c215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

